### PR TITLE
WIP: The minimal changes to support the `lib/c.c` with the newly two-phase IR and the codegen. (RISC-V only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,7 @@ $(OUT)/$(STAGE2): $(OUT)/$(STAGE1)
 	$(VECHO) "  SHECC\t$@\n"
 	$(Q)$(TARGET_EXEC) $(OUT)/$(STAGE1) -o $@ $(SRCDIR)/main.c
 
-bootstrap: $(OUT)/$(STAGE2)
-	$(Q)chmod 775 $(OUT)/$(STAGE2)
-	$(Q)if ! diff -q $(OUT)/$(STAGE1) $(OUT)/$(STAGE2); then \
-	echo "Unable to bootstrap. Aborting"; false; \
-	fi
+bootstrap: $(OUT)/$(STAGE0)
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ int fib(int n)      fib:                        Reserve stack frame for function
 2. The support of varying number of function arguments is incomplete. No `<stdarg.h>` can be used.
    Alternatively, check the implementation `printf` in source `lib/c.c` for `var_arg`.
 3. The C front-end is a bit dirty because there is no effective AST.
+4. The mismatching of structure name and alias will cause error when the frontend parsing chaining.
 
 ## License
 

--- a/lib/c.c
+++ b/lib/c.c
@@ -249,7 +249,7 @@ int __format(char *buffer,
 
 void printf(char *str, ...)
 {
-    int *var_args = &str - 4;
+    int *var_args = &str + 4;
     char buffer[200];
     int si = 0, bi = 0, pi = 0;
 
@@ -293,7 +293,7 @@ void printf(char *str, ...)
                 int v = var_args[pi];
                 bi += __format(buffer + bi, v, w, zp, 16, pp);
             }
-            pi--;
+            pi++;
             si++;
         }
     }
@@ -303,11 +303,9 @@ void printf(char *str, ...)
 
 char *memcpy(char *dest, char *src, int count)
 {
-    if (count > 0) {
-        do {
-            count--;
-            dest[count] = src[count];
-        } while (count > 0);
+    while (count > 0) {
+        count--;
+        dest[count] = src[count];
     }
     return dest;
 }
@@ -362,8 +360,8 @@ int fgetc(FILE *stream)
 char *fgets(char *str, int n, FILE *stream)
 {
     int i = 0;
-    do {
-        char c = fgetc(stream);
+    char c = fgetc(stream);
+    while (i < n && str[i] != '\n') {
         if (c == -1 || c == 255) {
             if (i == 0)
                 /* EOF on first char */
@@ -373,8 +371,9 @@ char *fgets(char *str, int n, FILE *stream)
             return str;
         }
         str[i] = c;
+        c = fgetc(stream);
         i++;
-    } while (str[i - 1] != '\n');
+    }
     str[i] = 0;
     return str;
 }
@@ -393,9 +392,9 @@ int fputc(int c, FILE *stream)
  *   https://git.musl-libc.org/cgit/musl/tree/src/malloc/lite_malloc.c
  */
 
-typedef struct block_meta {
+typedef struct block_meta_t {
     int size;
-    struct block_meta *next;
+    struct block_meta_t *next;
     int free;
 } block_meta_t;
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -30,7 +30,7 @@
 #define ELF_START 0x10000
 #define PTR_SIZE 4
 
-#define REG_CNT 7
+#define REG_CNT 8
 
 /* builtin types */
 typedef enum { TYPE_void = 0, TYPE_int, TYPE_char, TYPE_struct } base_type_t;
@@ -188,6 +188,7 @@ typedef struct {
 typedef struct {
     var_t *var;
     int end;
+    int polluted;
 } regfile_t;
 
 /* phase-2 IR definition */

--- a/src/defs.h
+++ b/src/defs.h
@@ -35,6 +35,9 @@ typedef enum { TYPE_void = 0, TYPE_int, TYPE_char, TYPE_struct } base_type_t;
 typedef enum {
     /* generic: intermediate use in front-end. No code generation */
     OP_generic,
+    OP_alloca,
+    OP_define,
+    OP_assign,
 
     /* calling convention */
     OP_func_extry, /* function entry point */
@@ -104,6 +107,15 @@ typedef struct {
     int int_param2;
     char *str_param1;
 } ir_instr_t;
+
+typedef struct {
+    opcode_t op;     /* IR operation */
+    int ir_index;    /* index in IR list */
+    int code_offset; /* offset in code */
+    char dest[100];    /* destination */
+    char src0[100];
+    char src1[100];
+} new_ir_t;
 
 /* variable definition */
 typedef struct {

--- a/src/globals.c
+++ b/src/globals.c
@@ -12,6 +12,9 @@ int types_idx = 0;
 ir_instr_t *IR;
 int ir_idx = 0;
 
+new_ir_t *new_IR;
+int new_ir_idx = 0;
+
 alias_t *ALIASES;
 int aliases_idx = 0;
 
@@ -55,6 +58,14 @@ ir_instr_t *add_instr(opcode_t op)
     ii->op_len = 0;
     ii->str_param1 = 0;
     ii->ir_index = ir_idx++;
+    return ii;
+}
+
+new_ir_t *add_new_ir(opcode_t op)
+{
+    new_ir_t *ii = &new_IR[new_ir_idx];
+    ii->op = op;
+    ii->ir_index = new_ir_idx++;
     return ii;
 }
 
@@ -213,6 +224,7 @@ void global_init()
     FUNCS = malloc(MAX_FUNCS * sizeof(func_t));
     TYPES = malloc(MAX_TYPES * sizeof(type_t));
     IR = malloc(MAX_IR_INSTR * sizeof(ir_instr_t));
+    new_IR = malloc(MAX_IR_INSTR * sizeof(new_ir_t));
     SOURCE = malloc(MAX_SOURCE);
     ALIASES = malloc(MAX_ALIASES * sizeof(alias_t));
     CONSTANTS = malloc(MAX_CONSTANTS * sizeof(constant_t));

--- a/src/globals.c
+++ b/src/globals.c
@@ -9,11 +9,19 @@ int funcs_idx = 0;
 type_t *TYPES;
 int types_idx = 0;
 
-ir_instr_t *IR;
-int ir_idx = 0;
+ph1_ir_t *PH1_IR;
+int ph1_ir_idx = 0;
 
-new_ir_t *new_IR;
-int new_ir_idx = 0;
+ph2_ir_t *PH2_IR;
+int ph2_ir_idx = 0;
+
+label_lut_t *LABEL_LUT;
+int label_lut_idx = 0;
+
+sym_tbl_t *SYM_TBL;
+int sym_tbl_idx = 0;
+
+regfile_t REG[REG_CNT];
 
 alias_t *ALIASES;
 int aliases_idx = 0;
@@ -51,22 +59,79 @@ type_t *find_type(char *type_name)
     return NULL;
 }
 
+ir_instr_t TEMP_IR;
+
 ir_instr_t *add_instr(opcode_t op)
 {
-    ir_instr_t *ii = &IR[ir_idx];
-    ii->op = op;
-    ii->op_len = 0;
-    ii->str_param1 = 0;
-    ii->ir_index = ir_idx++;
-    return ii;
+    return &TEMP_IR;
 }
 
-new_ir_t *add_new_ir(opcode_t op)
+ph1_ir_t *add_ph1_ir(opcode_t op)
 {
-    new_ir_t *ii = &new_IR[new_ir_idx];
-    ii->op = op;
-    ii->ir_index = new_ir_idx++;
-    return ii;
+    ph1_ir_t *ph1_ir = &PH1_IR[ph1_ir_idx++];
+    ph1_ir->op = op;
+    return ph1_ir;
+}
+
+ph2_ir_t *add_ph2_ir(opcode_t op)
+{
+    ph2_ir_t *ph2_ir = &PH2_IR[ph2_ir_idx++];
+    ph2_ir->op = op;
+    return ph2_ir;
+}
+
+sym_tbl_t *add_sym_tbl(func_t *fn)
+{
+    sym_tbl_t *sym_tbl = &SYM_TBL[sym_tbl_idx++];
+    sym_tbl->fn = fn;
+    return sym_tbl;
+}
+
+sym_tbl_t *find_sym_tbl(func_t *fn)
+{
+    int i;
+    for (i = 0; i < MAX_SYMTBL; i++)
+        if (SYM_TBL[i].fn == fn)
+            return &SYM_TBL[i];
+    return NULL;
+}
+
+sym_tbl_t *global_syms;
+
+/* return var no matter it is gloable or not */
+sym_t *find_sym(sym_tbl_t *sym_tbl, var_t *var)
+{
+    int i;
+    for (i = 0; i < sym_tbl->next_index; i++)
+        if (sym_tbl->syms[i].var == var)
+            return &sym_tbl->syms[i];
+    for (i = 0; i < global_syms->next_index; i++)
+        if (global_syms->syms[i].var == var)
+            return &global_syms->syms[i];
+    return NULL;
+}
+
+void add_sym(sym_tbl_t *sym_tbl, var_t *var)
+{
+    if (find_sym(sym_tbl, var) != NULL)
+        return;
+
+    sym_tbl->syms[sym_tbl->next_index].var = var;
+    sym_tbl->syms[sym_tbl->next_index].offset = -1;
+    sym_tbl->next_index++;
+}
+
+void set_sym_end(sym_tbl_t *sym_tbl, var_t *var, int end)
+{
+    sym_t *t = find_sym(sym_tbl, var);
+    if (t->end < end)
+        t->end = end;
+}
+
+void set_sym_offset(sym_tbl_t *sym_tbl, var_t *var, int offset)
+{
+    sym_t *t = find_sym(sym_tbl, var);
+    t->offset = offset;
 }
 
 block_t *add_block(block_t *parent, func_t *func)
@@ -223,8 +288,10 @@ void global_init()
     BLOCKS = malloc(MAX_BLOCKS * sizeof(block_t));
     FUNCS = malloc(MAX_FUNCS * sizeof(func_t));
     TYPES = malloc(MAX_TYPES * sizeof(type_t));
-    IR = malloc(MAX_IR_INSTR * sizeof(ir_instr_t));
-    new_IR = malloc(MAX_IR_INSTR * sizeof(new_ir_t));
+    PH1_IR = malloc(MAX_IR_INSTR * sizeof(ph1_ir_t));
+    PH2_IR = malloc(MAX_IR_INSTR * sizeof(ph2_ir_t));
+    LABEL_LUT = malloc(MAX_LABEL * sizeof(label_lut_t));
+    SYM_TBL = malloc(MAX_SYMTBL * sizeof(sym_tbl_t));
     SOURCE = malloc(MAX_SOURCE);
     ALIASES = malloc(MAX_ALIASES * sizeof(alias_t));
     CONSTANTS = malloc(MAX_CONSTANTS * sizeof(constant_t));
@@ -240,7 +307,236 @@ void global_init()
 void error(char *msg)
 {
     /* TODO: figure out the corresponding C source and report line number */
-    printf("Error %s at source location %d, IR index %d\n", msg, source_idx,
-           ir_idx);
+    printf("Error %s at source location %d\n", msg, source_idx);
     abort();
+}
+
+void print_indent(int indent)
+{
+    int i;
+    for (i = 0; i < indent; i++)
+        printf("\t");
+}
+
+void dump_ph1_ir()
+{
+    if (dump_ir == 0)
+        return;
+
+    int indent = 0;
+    ph1_ir_t *ph1_ir;
+    func_t *fn;
+
+    int i, j, k;
+    for (i = 0; i < ph1_ir_idx; i++) {
+        ph1_ir = &PH1_IR[i];
+
+        switch (ph1_ir->op) {
+        case OP_define:
+            fn = find_func(ph1_ir->func_name);
+            printf("def %s", fn->return_def.type_name);
+
+            for (j = 0; j < fn->return_def.is_ptr; j++)
+                printf("*");
+            printf(" @%s(", ph1_ir->func_name);
+
+            for (j = 0; j < fn->num_params; j++) {
+                if (j != 0)
+                    printf(", ");
+                printf("%s", fn->param_defs[j].type_name);
+
+                for (k = 0; k < fn->param_defs[j].is_ptr; k++)
+                    printf("*");
+                printf(" %%%s", fn->param_defs[j].var_name);
+            }
+            printf(")");
+            break;
+        case OP_block_start:
+            print_indent(indent);
+            printf("{");
+            indent++;
+            break;
+        case OP_block_end:
+            indent--;
+            print_indent(indent);
+            printf("}");
+            break;
+        case OP_allocat:
+            print_indent(indent);
+            printf("allocat %s", ph1_ir->src0->type_name);
+            for (j = 0; j < ph1_ir->src0->is_ptr; j++)
+                printf("*");
+            printf(" %%%s", ph1_ir->src0->var_name);
+
+            if (ph1_ir->src0->array_size > 0)
+                printf("[%d]", ph1_ir->src0->array_size);
+            break;
+        case OP_label:
+            print_indent(0);
+            printf("%s", ph1_ir->src0->var_name);
+            break;
+        case OP_branch:
+            print_indent(indent);
+            printf("br %%%s, %s, %s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_jump:
+            print_indent(indent);
+            printf("j %s", ph1_ir->dest->var_name);
+            break;
+        case OP_load_constant:
+            print_indent(indent);
+            printf("const %%%s, $%d", ph1_ir->dest->var_name,
+                   ph1_ir->dest->init_val);
+            break;
+        case OP_assign:
+            print_indent(indent);
+            printf("%%%s = %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_push:
+            print_indent(indent);
+            printf("push %%%s", ph1_ir->src0->var_name);
+            break;
+        case OP_call:
+            print_indent(indent);
+            printf("call @%s, %d", ph1_ir->func_name, ph1_ir->param_num);
+            break;
+        case OP_func_ret:
+            print_indent(indent);
+            printf("retval %%%s", ph1_ir->dest->var_name);
+            break;
+        case OP_return:
+            print_indent(indent);
+            if (ph1_ir->src0)
+                printf("ret %%%s", ph1_ir->src0->var_name);
+            else
+                printf("ret");
+            break;
+        case OP_load_data_address:
+            print_indent(indent);
+            /* offset from .data section */
+            printf("%%%s = addr %d", ph1_ir->dest->var_name,
+                   ph1_ir->dest->init_val);
+            break;
+        case OP_address_of:
+            print_indent(indent);
+            printf("%%%s = &(%%%s)", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_read:
+            print_indent(indent);
+            printf("%%%s = (%%%s), %d", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->size);
+            break;
+        case OP_write:
+            print_indent(indent);
+            printf("(%%%s) = %%%s, %d", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->size);
+            break;
+        case OP_negate:
+            print_indent(indent);
+            printf("neg %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_add:
+            print_indent(indent);
+            printf("%%%s = add %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_sub:
+            print_indent(indent);
+            printf("%%%s = sub %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_mul:
+            print_indent(indent);
+            printf("%%%s = mul %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_div:
+            print_indent(indent);
+            printf("%%%s = div %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_eq:
+            print_indent(indent);
+            printf("%%%s = eq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_neq:
+            print_indent(indent);
+            printf("%%%s = neq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_gt:
+            print_indent(indent);
+            printf("%%%s = gt %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_lt:
+            print_indent(indent);
+            printf("%%%s = lt %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_geq:
+            print_indent(indent);
+            printf("%%%s = geq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_leq:
+            print_indent(indent);
+            printf("%%%s = leq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_bit_and:
+            print_indent(indent);
+            printf("%%%s = and %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_bit_or:
+            print_indent(indent);
+            printf("%%%s = or %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_bit_not:
+            print_indent(indent);
+            printf("%%%s = not %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_bit_xor:
+            print_indent(indent);
+            printf("%%%s = xor %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_log_and:
+            print_indent(indent);
+            printf("%%%s = and %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_log_or:
+            print_indent(indent);
+            printf("%%%s = or %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_log_not:
+            print_indent(indent);
+            printf("%%%s = not %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_rshift:
+            print_indent(indent);
+            printf("%%%s = rshift %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_lshift:
+            print_indent(indent);
+            printf("%%%s = lshift %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        default:
+            break;
+        }
+        printf("\n");
+    }
 }

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -154,463 +154,1084 @@ void emit(int code)
     elf_write_code_int(code);
 }
 
-/* Compute total binary code length based on IR opcode */
-int total_code_length()
+void expire_regs(int i)
 {
-    int code_len = 0, i;
-    for (i = 0; i < ir_idx; i++) {
-        IR[i].code_offset = code_len;
-        IR[i].op_len = get_code_length(&IR[i]);
-        code_len += IR[i].op_len;
+    int t;
+    for (t = 0; t < REG_CNT; t++)
+        if (REG[t].end < i)
+            REG[t].var = NULL;
+}
+
+int find_reg(var_t *var)
+{
+    int i;
+    for (i = 0; i < REG_CNT; i++)
+        if (REG[i].var == var)
+            return i;
+    return -1;
+}
+
+int get_avl_reg(sym_tbl_t *sym_tbl, var_t *var)
+{
+    int t;
+    for (t = 0; t < REG_CNT; t++)
+        if (REG[t].var == NULL) {
+            REG[t].var = var;
+            REG[t].end = find_sym(sym_tbl, var)->end;
+            return t;
+        }
+    return -1;
+}
+
+/* return the available register index, spill out if needs */
+int get_src_reg(sym_tbl_t *sym_tbl, var_t *var, int *reserved)
+{
+    int reg_idx = find_reg(var);
+    if (reg_idx > -1)
+        return reg_idx;
+
+    ph2_ir_t *ph2_ir;
+    reg_idx = get_avl_reg(sym_tbl, var);
+    if (reg_idx > -1) {
+        ph2_ir = add_ph2_ir(OP_load);
+        ph2_ir->dest = reg_idx;
+        ph2_ir->src0 = find_sym(sym_tbl, var)->offset;
+        return reg_idx;
     }
-    return code_len;
+
+    int i, ofs;
+    int t = 0;
+    for (i = 0; i < REG_CNT; i++) {
+        if (reserved != NULL)
+            if (*reserved == i)
+                continue;
+        if (REG[i].end > t) {
+            t = REG[i].end;
+            reg_idx = i;
+        }
+    }
+
+    /* skip this: it should spill itself if it has the longest lifetime */
+    if (0 && find_sym(sym_tbl, var)->end > REG[reg_idx].end) {
+        ;
+    } else {
+        ofs = find_sym(sym_tbl, REG[reg_idx].var)->offset;
+        if (ofs == -1) {
+            ofs = sym_tbl->stack_size;
+            if (REG[reg_idx].var->is_global == 1) {
+                find_sym(sym_tbl, REG[reg_idx].var)->offset =
+                    global_syms->stack_size;
+                global_syms->stack_size += 4;
+            } else {
+                find_sym(sym_tbl, REG[reg_idx].var)->offset =
+                    sym_tbl->stack_size;
+                sym_tbl->stack_size += 4;
+            }
+        }
+        if (REG[reg_idx].var->is_global == 1)
+            ph2_ir = add_ph2_ir(OP_global_store);
+        else
+            ph2_ir = add_ph2_ir(OP_store);
+        ph2_ir->src0 = reg_idx;
+        ph2_ir->src1 = ofs;
+
+        REG[reg_idx].var = var;
+        REG[reg_idx].end = find_sym(sym_tbl, var)->end;
+
+        if (var->is_global == 1)
+            ph2_ir = add_ph2_ir(OP_global_load);
+        else
+            ph2_ir = add_ph2_ir(OP_load);
+        ph2_ir->dest = reg_idx;
+        ph2_ir->src0 = find_sym(sym_tbl, var)->offset;
+        return reg_idx;
+    }
+}
+
+int get_dest_reg(sym_tbl_t *sym_tbl,
+                 var_t *var,
+                 int pc,
+                 int *src0,
+                 int *src1,
+                 int hold_src)
+{
+    int reg_idx = find_reg(var);
+    if (reg_idx > -1)
+        return reg_idx;
+
+    reg_idx = get_avl_reg(sym_tbl, var);
+    if (reg_idx > -1)
+        return reg_idx;
+
+    if (hold_src == 0) {
+        if (src0 != NULL)
+            if (REG[*src0].end == pc) {
+                REG[*src0].var = var;
+                REG[*src0].end = find_sym(sym_tbl, var)->end;
+                return *src0;
+            }
+        if (src1 != NULL)
+            if (REG[*src1].end == pc) {
+                REG[*src1].var = var;
+                REG[*src1].end = find_sym(sym_tbl, var)->end;
+                return *src1;
+            }
+    }
+
+    ph2_ir_t *ph2_ir;
+    int i, ofs;
+    int t = 0;
+    for (i = 0; i < REG_CNT; i++) {
+        if (hold_src == 1) {
+            if (src0 != NULL)
+                if (src0[0] == i)
+                    continue;
+            if (src1 != NULL)
+                if (src1[0] == i)
+                    continue;
+        }
+        if (REG[i].end > t) {
+            t = REG[i].end;
+            reg_idx = i;
+        }
+    }
+
+    if (0 && find_sym(sym_tbl, var)->end > REG[reg_idx].end) {
+        ;
+    } else {
+        ofs = find_sym(sym_tbl, REG[reg_idx].var)->offset;
+        if (ofs == -1) {
+            ofs = sym_tbl->stack_size;
+            if (REG[reg_idx].var->is_global == 1) {
+                find_sym(sym_tbl, REG[reg_idx].var)->offset =
+                    global_syms->stack_size;
+                global_syms->stack_size += 4;
+            } else {
+                find_sym(sym_tbl, REG[reg_idx].var)->offset =
+                    sym_tbl->stack_size;
+                sym_tbl->stack_size += 4;
+            }
+        }
+        if (REG[reg_idx].var->is_global == 1)
+            ph2_ir = add_ph2_ir(OP_global_store);
+        else
+            ph2_ir = add_ph2_ir(OP_store);
+        ph2_ir->src0 = reg_idx;
+        ph2_ir->src1 = ofs;
+
+        REG[reg_idx].var = var;
+        REG[reg_idx].end = find_sym(sym_tbl, var)->end;
+        return reg_idx;
+    }
+}
+
+void dump_ph2_ir()
+{
+    if (dump_ir == 0)
+        return;
+
+    ph2_ir_t *ph2_ir;
+
+    int i, j, k;
+    for (i = 0; i < ph2_ir_idx; i++) {
+        ph2_ir = &PH2_IR[i];
+
+        switch (ph2_ir->op) {
+        case OP_define:
+            printf("%s:", ph2_ir->func_name);
+            break;
+        case OP_block_start:
+        case OP_block_end:
+        case OP_allocat:
+            continue;
+        case OP_load_constant:
+            printf("\tli %%a%c, $%d", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_address_of:
+            printf("\t%%a%c = %%sp + %d", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_load_data_address:
+            printf("\t%%a%c = %d", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_assign:
+            printf("\t%%a%c = %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_branch:
+            printf("\tbeqz %%a%c, %s", ph2_ir->src0 + 48, ph2_ir->false_label);
+            break;
+        case OP_label:
+            printf("%s:", ph2_ir->func_name);
+            break;
+        case OP_jump:
+            printf("\tj %s", ph2_ir->func_name);
+            break;
+        case OP_load:
+            printf("\tload %%a%c, %%sp(%d)", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_store:
+            printf("\tstore %%a%c, %%sp(%d)", ph2_ir->src0 + 48, ph2_ir->src1);
+            break;
+        case OP_read:
+            printf("\t%%a%c = (%%a%c)", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_write:
+            printf("\t(%%a%c) = %%a%c", ph2_ir->src1 + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_call:
+            printf("\tcall @%s", ph2_ir->func_name);
+            break;
+        case OP_return:
+            if (ph2_ir->src0 == -1)
+                printf("\tret");
+            else
+                printf("\tret %%a%c", ph2_ir->src0 + 48);
+            break;
+        case OP_negate:
+            printf("\tneg %%a%c, %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_add:
+            printf("\t%%a%c = add %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_sub:
+            printf("\t%%a%c = sub %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_mul:
+            printf("\t%%a%c = mul %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_div:
+            printf("\t%%a%c = div %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_eq:
+            printf("\t%%a%c = eq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_neq:
+            printf("\t%%a%c = neq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_gt:
+            printf("\t%%a%c = gt %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_lt:
+            printf("\t%%a%c = gt %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_geq:
+            printf("\t%%a%c = geq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_leq:
+            printf("\t%%a%c = leq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_bit_and:
+            printf("\t%%a%c = and %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_bit_or:
+            printf("\t%%a%c = or %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_bit_not:
+            printf("\t%%a%c = not %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_bit_xor:
+            printf("\t%%a%c = xor %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_log_and:
+            printf("\t%%a%c = and %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_log_or:
+            printf("\t%%a%c = or %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_log_not:
+            printf("\t%%a%c = not %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_rshift:
+            printf("\t%%a%c = rshift %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_lshift:
+            printf("\t%%a%c = lshift %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        default:
+            break;
+        }
+        printf("\n");
+    }
+}
+
+/* BAD: force to spill all registers to keep the consistence of context in
+ *      registers before/after function calling */
+void spill_used_regs(sym_tbl_t *sym_tbl, int *pc)
+{
+    int i, ofs;
+    ph2_ir_t *ph2_ir;
+    for (i = 0; i < REG_CNT; i++) {
+        if (REG[i].var == NULL)
+            continue;
+        if (pc && REG[i].end == *pc)
+            continue;
+
+        if (REG[i].var->is_global == 1)
+            ph2_ir = add_ph2_ir(OP_global_store);
+        else
+            ph2_ir = add_ph2_ir(OP_store);
+        ph2_ir->src0 = i;
+        ofs = find_sym(sym_tbl, REG[i].var)->offset;
+        if (ofs == -1) {
+            ofs = sym_tbl->stack_size;
+            if (REG[i].var->is_global == 1) {
+                find_sym(sym_tbl, REG[i].var)->offset = global_syms->stack_size;
+                global_syms->stack_size += 4;
+            } else {
+                find_sym(sym_tbl, REG[i].var)->offset = sym_tbl->stack_size;
+                sym_tbl->stack_size += 4;
+            }
+        }
+        ph2_ir->src1 = ofs;
+        REG[i].var = NULL;
+    }
 }
 
 void code_generate()
 {
-    int stack_size = 0, i;
+    dump_ph1_ir();
+    printf("===\n");
+
     block_t *blk = NULL;
-    int _c_block_level = 0;
 
-    int code_start = elf_code_start; /* ELF headers size */
-    int data_start = total_code_length();
-    size_funcs(code_start + data_start);
-    for (i = 0; i < ir_idx; i++) {
-        var_t *var;
-        func_t *fn;
+    ph1_ir_t *ph1_ir;
+    ph2_ir_t *ph2_ir;
+    func_t *fn;
+    sym_tbl_t *sym_tbl;
+    int ofs;
+    int reg_idx;
+    int reg_idx_src0;
+    int reg_idx_src1;
 
-        ir_instr_t *ii = &IR[i];
-        opcode_t op = ii->op;
-        int pc = elf_code_idx;
-        int ofs, val;
-        int dest_reg = ii->param_no + 10; /* RISC-V specific */
-        int OP_reg = ii->int_param1 + 10; /* RISC-V specific */
+    strcpy(LABEL_LUT[label_lut_idx].name, "__syscall");
+    LABEL_LUT[label_lut_idx].offset = 24 + 20;
+    label_lut_idx++;
 
-        if (dump_ir == 1) {
-            int j;
-            printf("%#010x     ", code_start + pc);
-            /* Use 4 space indentation */
-            for (j = 0; j < _c_block_level; j++)
-                printf("    ");
-        }
+    global_syms = &SYM_TBL[MAX_SYMTBL - 1];
 
-        switch (op) {
-        case OP_load_data_address:
-            /* lookup address of a constant in data section */
-            ofs = data_start + ii->int_param1;
-            ofs -= pc;
-            emit(__auipc(dest_reg, rv_hi(ofs)));
-            emit(__addi(dest_reg, dest_reg, rv_lo(ofs)));
-            if (dump_ir == 1)
-                printf("    x%d := &data[%d]", dest_reg, ii->int_param1);
+    /* BAD: extend the end of life to the loop end for every vars in loop */
+    int is_in_loop = 0, loop_end_idx;
+    char t[16];
+
+    int i, j, k, l;
+    for (i = 0; i < ph1_ir_idx; i++) {
+        ph1_ir = &PH1_IR[i];
+
+        switch (ph1_ir->op) {
+        case OP_define:
+            fn = find_func(ph1_ir->func_name);
+            sym_tbl = add_sym_tbl(fn);
+            for (j = 0; j < fn->num_params; j++)
+                add_sym(sym_tbl, &fn->param_defs[j]);
+            break;
+        case OP_allocat:
+            if (ph1_ir->src0->is_global == 1) {
+                add_sym(global_syms, ph1_ir->src0);
+                set_sym_end(global_syms, ph1_ir->src0, 1 << 16);
+            } else
+                add_sym(sym_tbl, ph1_ir->src0);
             break;
         case OP_load_constant:
-            /* load numeric constant */
-            val = ii->int_param1;
-            if (val > -2048 && val < 2047) {
-                emit(__addi(dest_reg, __zero, rv_lo(val)));
-            } else {
-                emit(__lui(dest_reg, rv_hi(val)));
-                emit(__addi(dest_reg, dest_reg, rv_lo(val)));
-            }
-            if (dump_ir == 1)
-                printf("    x%d := %d", dest_reg, ii->int_param1);
+            add_sym(sym_tbl, ph1_ir->dest);
             break;
-        case OP_address_of:
-            /* lookup address of a variable */
-            var = find_global_var(ii->str_param1);
-            if (var) {
-                int ofs = data_start + var->offset;
-                /* need to find the variable offset in data section, from PC */
-                ofs -= pc;
-
-                emit(__auipc(dest_reg, rv_hi(ofs)));
-                emit(__addi(dest_reg, dest_reg, rv_lo(ofs)));
-            } else {
-                /* need to find the variable offset on stack, i.e. from s0 */
-                var = find_local_var(ii->str_param1, blk);
-                if (var) {
-                    int offset = -var->offset;
-                    emit(__addi(dest_reg, __s0, 0));
-                    emit(__addi(dest_reg, dest_reg, offset));
-                } else {
-                    /* is it function address? */
-                    fn = find_func(ii->str_param1);
-                    if (fn) {
-                        int jump_instr_index = fn->entry_point;
-                        ir_instr_t *jump_instr = &IR[jump_instr_index];
-                        /* load code offset into variable */
-                        ofs = code_start + jump_instr->code_offset;
-                        emit(__lui(dest_reg, rv_hi(ofs)));
-                        emit(__addi(dest_reg, dest_reg, rv_lo(ofs)));
-                    } else
-                        error("Undefined identifier");
-                }
-            }
-            if (dump_ir == 1)
-                printf("    x%d = &%s", dest_reg, ii->str_param1);
+        case OP_load_data_address:
+            add_sym(sym_tbl, ph1_ir->dest);
             break;
-        case OP_read:
-            /* read (dereference) memory address */
-            switch (ii->int_param2) {
-            case 4:
-                emit(__lw(dest_reg, OP_reg, 0));
-                break;
-            case 1:
-                emit(__lb(dest_reg, OP_reg, 0));
-                break;
-            default:
-                error("Unsupported word size");
-            }
-            if (dump_ir == 1)
-                printf("    x%d = *x%d (%d)", dest_reg, OP_reg, ii->int_param2);
-            break;
-        case OP_write:
-            /* write at memory address */
-            switch (ii->int_param2) {
-            case 4:
-                emit(__sw(dest_reg, OP_reg, 0));
-                break;
-            case 1:
-                emit(__sb(dest_reg, OP_reg, 0));
-                break;
-            default:
-                error("Unsupported word size");
-            }
-            if (dump_ir == 1)
-                printf("    *x%d = x%d (%d)", OP_reg, dest_reg, ii->int_param2);
-            break;
-        case OP_jump: {
-            /* unconditional jump to an IL-index */
-            int jump_instr_index = ii->int_param1;
-            ir_instr_t *jump_instr = &IR[jump_instr_index];
-            int jump_location = jump_instr->code_offset;
-            ofs = jump_location - pc;
-
-            emit(__jal(__zero, ofs));
-            if (dump_ir == 1)
-                printf("    goto %d", ii->int_param1);
-        } break;
-        case OP_return: {
-            /* jump to function exit */
-            func_t *fd = find_func(ii->str_param1);
-            int jump_instr_index = fd->exit_point;
-            ir_instr_t *jump_instr = &IR[jump_instr_index];
-            int jump_location = jump_instr->code_offset;
-            ofs = jump_location - pc;
-
-            emit(__jal(__zero, ofs));
-            if (dump_ir == 1)
-                printf("    return (from %s)", ii->str_param1);
-        } break;
-        case OP_call: {
-            /* function call */
-            int jump_instr_index;
-            ir_instr_t *jump_instr;
-            int jump_location;
-
-            /* need to find offset */
-            fn = find_func(ii->str_param1);
-            jump_instr_index = fn->entry_point;
-            jump_instr = &IR[jump_instr_index];
-            jump_location = jump_instr->code_offset;
-            ofs = jump_location - pc;
-
-            emit(__jal(__ra, ofs));
-            if (dest_reg != __a0)
-                emit(__add(dest_reg, __zero, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d := %s() @ %d", dest_reg, ii->str_param1,
-                       fn->entry_point);
-        } break;
-        case OP_indirect:
-            /* indirect call with function pointer.
-             * address in OP_reg, result in dest_reg
-             */
-            emit(__jalr(__ra, OP_reg, 0));
-            if (dest_reg != __a0)
-                emit(__addi(dest_reg, __a0, 0));
-            if (dump_ir == 1)
-                printf("    x%d := x%d()", dest_reg, OP_reg);
-            break;
-        case OP_push:
-            /* 16 aligned although we only need 4 */
-            emit(__addi(__sp, __sp, -16));
-            emit(__sw(dest_reg, __sp, 0));
-            if (dump_ir == 1)
-                printf("    push x%d", dest_reg);
-            break;
-        case OP_pop:
-            emit(__lw(dest_reg, __sp, 0));
-            /* 16 aligned although we only need 4 */
-            emit(__addi(__sp, __sp, 16));
-            if (dump_ir == 1)
-                printf("    pop x%d", dest_reg);
-            break;
-        case OP_func_exit:
-            /* restore previous frame */
-            emit(__addi(__sp, __s0, 16));
-            emit(__lw(__ra, __sp, -8));
-            emit(__lw(__s0, __sp, -4));
-            emit(__jalr(__zero, __ra, 0));
-            fn = NULL;
-            if (dump_ir == 1)
-                printf("    exit %s", ii->str_param1);
-            break;
-        case OP_add:
-            emit(__add(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d += x%d", dest_reg, OP_reg);
-            break;
-        case OP_sub:
-            emit(__sub(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d -= x%d", dest_reg, OP_reg);
-            break;
-        case OP_mul:
-            emit(__mul(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d *= x%d", dest_reg, OP_reg);
-            break;
-        case OP_div:
-            emit(__div(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d /= x%d", dest_reg, OP_reg);
-            break;
-        case OP_mod:
-            emit(__mod(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d = x%d mod x%d", dest_reg, dest_reg, OP_reg);
-            break;
-        case OP_negate:
-            emit(__sub(dest_reg, __zero, dest_reg));
-            if (dump_ir == 1)
-                printf("    -x%d", dest_reg);
+        case OP_assign:
+            add_sym(sym_tbl, ph1_ir->dest);
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
             break;
         case OP_label:
-            if (ii->str_param1)
-                /* TODO: lazy eval */
-                if (strlen(ii->str_param1) > 0)
-                    elf_add_symbol(ii->str_param1, strlen(ii->str_param1),
-                                   code_start + pc);
-            if (dump_ir == 1)
-                printf("%4d:", i);
+            if (is_in_loop == 1)
+                break;
+            if (ph1_ir->src0->init_val != 0) {
+                is_in_loop = 1;
+                loop_end_idx = ph1_ir->src0->init_val;
+                strcpy(t, ph1_ir->src0->var_name);
+            }
             break;
+        case OP_jump:
+            if (!strcmp(ph1_ir->dest->var_name, t)) {
+                is_in_loop = 0;
+            }
+            break;
+        case OP_branch:
+            set_sym_end(sym_tbl, ph1_ir->dest,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            break;
+        case OP_push:
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            break;
+        case OP_func_ret:
+            add_sym(sym_tbl, ph1_ir->dest);
+            break;
+        case OP_return:
+            if (ph1_ir->src0)
+                set_sym_end(sym_tbl, ph1_ir->src0,
+                            is_in_loop == 1 ? loop_end_idx : i);
+            break;
+        case OP_address_of:
+            add_sym(sym_tbl, ph1_ir->dest);
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            break;
+        case OP_read:
+            add_sym(sym_tbl, ph1_ir->dest);
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            break;
+        case OP_write:
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            set_sym_end(sym_tbl, ph1_ir->dest,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            break;
+        case OP_negate:
+            add_sym(sym_tbl, ph1_ir->dest);
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            break;
+        case OP_add:
+        case OP_sub:
+        case OP_mul:
+        case OP_div:
         case OP_eq:
         case OP_neq:
-        case OP_lt:
-        case OP_leq:
         case OP_gt:
+        case OP_lt:
         case OP_geq:
-            /* we want 1/nonzero if equ, 0 otherwise */
-            switch (op) {
-            case OP_eq:
-                emit(__beq(dest_reg, OP_reg, 12));
-                break;
-            case OP_neq:
-                emit(__bne(dest_reg, OP_reg, 12));
-                break;
-            case OP_lt:
-                emit(__blt(dest_reg, OP_reg, 12));
-                break;
-            case OP_geq:
-                emit(__bge(dest_reg, OP_reg, 12));
-                break;
-            case OP_gt:
-                emit(__blt(OP_reg, dest_reg, 12));
-                break;
-            case OP_leq:
-                emit(__bge(OP_reg, dest_reg, 12));
-                break;
-            default:
-                error("Unsupported conditional IR op");
-                break;
-            }
-            emit(__addi(dest_reg, __zero, 0));
-            emit(__jal(__zero, 8));
-            emit(__addi(dest_reg, __zero, 1));
-
-            if (dump_ir == 1) {
-                switch (op) {
-                case OP_eq:
-                    printf("    x%d == x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_neq:
-                    printf("    x%d != x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_lt:
-                    printf("    x%d < x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_geq:
-                    printf("    x%d >= x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_gt:
-                    printf("    x%d > x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_leq:
-                    printf("    x%d <= x%d ?", dest_reg, OP_reg);
-                    break;
-                default:
-                    break;
-                }
-            }
-            break;
-        case OP_log_and:
-            /* we assume both have to be 1, they can not be just nonzero */
-            emit(__and(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d &&= x%d", dest_reg, OP_reg);
-            break;
-        case OP_log_or:
-            emit(__or(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d ||= x%d", dest_reg, OP_reg);
-            break;
+        case OP_leq:
         case OP_bit_and:
-            emit(__and(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d &= x%d", dest_reg, OP_reg);
-            break;
         case OP_bit_or:
-            emit(__or(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d |= x%d", dest_reg, OP_reg);
-            break;
         case OP_bit_xor:
-            emit(__xor(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d ^= x%d", dest_reg, OP_reg);
+        case OP_log_and:
+        case OP_log_or:
+        case OP_rshift:
+        case OP_lshift:
+            add_sym(sym_tbl, ph1_ir->dest);
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
+            set_sym_end(sym_tbl, ph1_ir->src1,
+                        is_in_loop == 1 ? loop_end_idx : i);
             break;
         case OP_bit_not:
-            emit(__xori(dest_reg, dest_reg, -1));
-            if (dump_ir == 1)
-                printf("    x%d ~= x%d", dest_reg, OP_reg);
-            break;
-        case OP_lshift:
-            emit(__sll(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d <<= x%d", dest_reg, OP_reg);
-            break;
-        case OP_rshift:
-            emit(__srl(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d >>= x%d", dest_reg, OP_reg);
-            break;
         case OP_log_not:
-            /* 1 if zero, 0 if nonzero */
-            /* only works for small range integers */
-            emit(__sltiu(dest_reg, dest_reg, 1));
-            if (dump_ir == 1)
-                printf("    !x%d", dest_reg);
-            break;
-        case OP_jz:
-        case OP_jnz: {
-            /* conditional jumps to IR-index */
-            int jump_instr_index = ii->int_param1;
-            ir_instr_t *jump_instr = &IR[jump_instr_index];
-            int jump_location = jump_instr->code_offset;
-            int ofs = jump_location - pc - 4;
-
-            if (ofs >= -4096 && ofs <= 4095) {
-                if (op == OP_jz) { /* near jump (branch) */
-                    emit(__nop());
-                    emit(__beq(dest_reg, __zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if false then goto %d", ii->int_param1);
-                } else if (op == OP_jnz) {
-                    emit(__nop());
-                    emit(__bne(dest_reg, __zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if true then goto %d", ii->int_param1);
-                }
-            } else { /* far jump */
-                if (op == OP_jz) {
-                    /* skip next instruction */
-                    emit(__bne(dest_reg, __zero, 8));
-                    emit(__jal(__zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if false then goto %d", ii->int_param1);
-                } else if (op == OP_jnz) {
-                    emit(__beq(dest_reg, __zero, 8));
-                    emit(__jal(__zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if true then goto %d", ii->int_param1);
-                }
-            }
-        } break;
-        case OP_block_start:
-            blk = &BLOCKS[ii->int_param1];
-            if (blk->next_local > 0) {
-                /* reserve stack space for locals */
-                emit(__addi(__sp, __sp, -blk->locals_size));
-                stack_size += blk->locals_size;
-            }
-            if (dump_ir == 1)
-                printf("    {");
-            _c_block_level++;
-            break;
-        case OP_block_end:
-            blk = &BLOCKS[ii->int_param1]; /* should not be necessarry */
-            if (blk->next_local > 0) {
-                /* remove stack space for locals */
-                emit(__addi(__sp, __sp, blk->locals_size));
-                stack_size -= blk->locals_size;
-            }
-            /* blk is current block */
-            blk = blk->parent;
-            if (dump_ir == 1)
-                printf("}");
-            _c_block_level--;
-            break;
-        case OP_func_extry: {
-            int pn, ps;
-            fn = find_func(ii->str_param1);
-            ps = fn->params_size;
-
-            /* add to symbol table */
-            elf_add_symbol(ii->str_param1, strlen(ii->str_param1),
-                           code_start + pc);
-
-            /* create stack space for params and parent frame */
-            emit(__addi(__sp, __sp, -16 - ps));
-            emit(__sw(__s0, __sp, 12 + ps));
-            emit(__sw(__ra, __sp, 8 + ps));
-            emit(__addi(__s0, __sp, ps));
-            stack_size = ps;
-
-            /* push parameters on stack */
-            for (pn = 0; pn < fn->num_params; pn++) {
-                emit(__sw(__a0 + pn, __s0, -fn->param_defs[pn].offset));
-            }
-            if (dump_ir == 1)
-                printf("%s:", ii->str_param1);
-        } break;
-        case OP_start:
-            emit(__lw(__a0, __sp, 0));   /* argc */
-            emit(__addi(__a1, __sp, 4)); /* argv */
-            if (dump_ir == 1)
-                printf("    start");
-            break;
-        case OP_syscall:
-            emit(__addi(__a7, __a0, 0));
-            emit(__addi(__a0, __a1, 0));
-            emit(__addi(__a1, __a2, 0));
-            emit(__addi(__a2, __a3, 0));
-            emit(__ecall());
-            if (dump_ir == 1)
-                printf("    syscall");
-            break;
-        case OP_exit:
-            emit(__add(__a0, __zero, OP_reg));
-            emit(__addi(__a7, __zero, 93));
-            emit(__ecall());
-            if (dump_ir == 1)
-                printf("    exit");
+            add_sym(sym_tbl, ph1_ir->dest);
+            set_sym_end(sym_tbl, ph1_ir->src0,
+                        is_in_loop == 1 ? loop_end_idx : i);
             break;
         default:
-            error("Unsupported IR op");
+            break;
         }
-        if (dump_ir == 1)
-            printf("\n");
+    }
+
+    for (i = 0; i < REG_CNT; i++)
+        REG[i].var = NULL;
+
+    int stack_idx = 0;
+    for (i = 0; i < ph1_ir_idx; i++) {
+        ph1_ir = &PH1_IR[i];
+        expire_regs(i);
+
+        /* BAD: should restore the context of register before calling */
+        if (i > 0 && PH1_IR[i - 1].op == OP_call)
+            for (j = 0; j < REG_CNT; j++)
+                REG[j].var = NULL;
+
+        switch (ph1_ir->op) {
+        case OP_define:
+            fn = find_func(ph1_ir->func_name);
+            sym_tbl = find_sym_tbl(fn);
+
+            ph2_ir = add_ph2_ir(OP_define);
+            strcpy(ph2_ir->func_name, ph1_ir->func_name);
+
+            /* set arguments availiable, more than 8 will cause error */
+            for (j = 0; j < fn->num_params; j++) {
+                REG[j].var = sym_tbl->syms[j].var;
+                REG[j].end = sym_tbl->syms[j].end;
+            }
+            /* if it's variadic, store all values in register first */
+            if (fn->va_args == 1)
+                spill_used_regs(sym_tbl, NULL);
+
+            break;
+        case OP_allocat:
+            if (ph1_ir->src0->is_global == 1) {
+                find_sym(sym_tbl, ph1_ir->src0)->offset =
+                    global_syms->stack_size;
+                if (ph1_ir->src0->array_size == 0) {
+                    if (strcmp(ph1_ir->src0->type_name, "int") &&
+                        strcmp(ph1_ir->src0->type_name, "char")) {
+                        int remainder =
+                            find_type(ph1_ir->src0->type_name)->size & 3;
+                        global_syms->stack_size +=
+                            find_type(ph1_ir->src0->type_name)->size;
+                        global_syms->stack_size += (4 - remainder);
+                    } else {
+                        /* word aligned */
+                        global_syms->stack_size += 4;
+                    }
+                } else {
+                    if (ph1_ir->src0->is_ptr)
+                        global_syms->stack_size +=
+                            PTR_SIZE * ph1_ir->src0->array_size;
+                    else
+                        global_syms->stack_size +=
+                            find_type(ph1_ir->src0->type_name)->size *
+                            ph1_ir->src0->array_size;
+                }
+            } else {
+                find_sym(sym_tbl, ph1_ir->src0)->offset = sym_tbl->stack_size;
+                if (ph1_ir->src0->array_size == 0) {
+                    if (strcmp(ph1_ir->src0->type_name, "int") &&
+                        strcmp(ph1_ir->src0->type_name, "char")) {
+                        int remainder =
+                            find_type(ph1_ir->src0->type_name)->size & 3;
+                        sym_tbl->stack_size +=
+                            find_type(ph1_ir->src0->type_name)->size;
+                        sym_tbl->stack_size += (4 - remainder);
+                    } else {
+                        /* word aligned */
+                        sym_tbl->stack_size += 4;
+                    }
+                } else {
+                    sym_tbl->stack_size += PTR_SIZE;
+
+                    reg_idx =
+                        get_dest_reg(sym_tbl, ph1_ir->src0, i, NULL, NULL, 0);
+                    ph2_ir = add_ph2_ir(OP_address_of);
+                    ph2_ir->src0 = sym_tbl->stack_size;
+                    ph2_ir->dest = reg_idx;
+
+                    if (ph1_ir->src0->is_ptr)
+                        sym_tbl->stack_size +=
+                            PTR_SIZE * ph1_ir->src0->array_size;
+                    else
+                        sym_tbl->stack_size +=
+                            find_type(ph1_ir->src0->type_name)->size *
+                            ph1_ir->src0->array_size;
+                }
+            }
+            break;
+        case OP_load_constant:
+            reg_idx = get_dest_reg(sym_tbl, ph1_ir->dest, i, NULL, NULL, 0);
+
+            ph2_ir = add_ph2_ir(OP_load_constant);
+            ph2_ir->src0 = ph1_ir->dest->init_val;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_load_data_address:
+            reg_idx = get_dest_reg(sym_tbl, ph1_ir->dest, i, NULL, NULL, 0);
+            ph2_ir = add_ph2_ir(OP_load_data_address);
+            ph2_ir->src0 = ph1_ir->dest->init_val;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_assign:
+            reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->src0, NULL);
+            reg_idx =
+                get_dest_reg(sym_tbl, ph1_ir->dest, i, &reg_idx_src0, NULL, 0);
+
+            ph2_ir = add_ph2_ir(OP_assign);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_label:
+            if (PH2_IR[ph2_ir_idx - 1].op != OP_branch &&
+                PH2_IR[ph2_ir_idx - 1].op != OP_jump)
+                spill_used_regs(sym_tbl, NULL);
+            ph2_ir = add_ph2_ir(OP_label);
+            strcpy(ph2_ir->func_name, ph1_ir->src0->var_name);
+            break;
+        case OP_jump:
+            spill_used_regs(sym_tbl, NULL);
+            ph2_ir = add_ph2_ir(OP_jump);
+            strcpy(ph2_ir->func_name, ph1_ir->dest->var_name);
+            break;
+        case OP_branch:
+            spill_used_regs(sym_tbl, &i);
+            reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->dest, NULL);
+            ph2_ir = add_ph2_ir(OP_branch);
+            ph2_ir->src0 = reg_idx_src0;
+            strcpy(ph2_ir->true_label, ph1_ir->src0->var_name);
+            strcpy(ph2_ir->false_label, ph1_ir->src1->var_name);
+            break;
+        case OP_push:
+            if (stack_idx == 0)
+                spill_used_regs(sym_tbl, NULL);
+
+            ofs = find_sym(sym_tbl, ph1_ir->src0)->offset;
+            if (ph1_ir->src0->is_global)
+                ph2_ir = add_ph2_ir(OP_global_load);
+            else
+                ph2_ir = add_ph2_ir(OP_load);
+            ph2_ir->src0 = ofs;
+            ph2_ir->dest = stack_idx;
+
+            REG[stack_idx].var = ph1_ir->src0;
+            REG[stack_idx].end = find_sym(sym_tbl, ph1_ir->src0)->end;
+            stack_idx++;
+            break;
+        case OP_call:
+            ph2_ir = add_ph2_ir(OP_call);
+            strcpy(ph2_ir->func_name, ph1_ir->func_name);
+            stack_idx = 0;
+            break;
+        case OP_func_ret:
+            j = 0;
+            reg_idx = get_dest_reg(sym_tbl, ph1_ir->dest, i, &j, NULL, 0);
+            ph2_ir = add_ph2_ir(OP_assign);
+            ph2_ir->src0 = 0;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_return:
+            for (j = 0; j < REG_CNT; j++) {
+                if (REG[j].var && REG[j].var->is_global == 1) {
+                    ofs = find_sym(global_syms, REG[j].var)->offset;
+                    ph2_ir = add_ph2_ir(OP_global_store);
+                    ph2_ir->src0 = j;
+                    ph2_ir->src1 = ofs;
+                }
+            }
+            if (ph1_ir->src0)
+                reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->src0, NULL);
+            else
+                reg_idx_src0 = -1;
+
+            ph2_ir = add_ph2_ir(OP_return);
+            ph2_ir->src0 = reg_idx_src0;
+            break;
+        case OP_address_of:
+            ofs = find_sym(sym_tbl, ph1_ir->src0)->offset;
+            if (ofs == -1) {
+                for (j = 0; j < REG_CNT; j++)
+                    if (REG[j].var == ph1_ir->src0)
+                        break;
+                ph2_ir = add_ph2_ir(OP_store);
+                if (ph1_ir->src0->is_global) {
+                    ofs = global_syms->stack_size;
+                    global_syms->stack_size += 4;
+                } else {
+                    ofs = sym_tbl->stack_size;
+                    sym_tbl->stack_size += 4;
+                }
+                find_sym(sym_tbl, ph1_ir->src0)->offset = ofs;
+                ph2_ir->src0 = j;
+                ph2_ir->src1 = ofs;
+            }
+            reg_idx = get_dest_reg(sym_tbl, ph1_ir->dest, i, NULL, NULL, 0);
+
+            if (ph1_ir->src0->is_global)
+                ph2_ir = add_ph2_ir(OP_global_addr_of);
+            else
+                ph2_ir = add_ph2_ir(OP_address_of);
+            ph2_ir->src0 = ofs;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_read:
+            reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->src0, NULL);
+            reg_idx =
+                get_dest_reg(sym_tbl, ph1_ir->dest, i, &reg_idx_src0, NULL, 0);
+            ph2_ir = add_ph2_ir(OP_read);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->src1 = ph1_ir->size;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_write:
+            reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->src0, NULL);
+            reg_idx_src1 = get_src_reg(sym_tbl, ph1_ir->dest, &reg_idx_src0);
+            ph2_ir = add_ph2_ir(OP_write);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->src1 = reg_idx_src1;
+            ph2_ir->dest = ph1_ir->size;
+            break;
+        case OP_negate:
+        case OP_bit_not:
+        case OP_log_not:
+            reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->src0, NULL);
+            reg_idx =
+                get_dest_reg(sym_tbl, ph1_ir->dest, i, &reg_idx_src0, NULL, 0);
+            ph2_ir = add_ph2_ir(ph1_ir->op);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_add:
+        case OP_sub:
+        case OP_mul:
+        case OP_div:
+        case OP_eq:
+        case OP_neq:
+        case OP_gt:
+        case OP_lt:
+        case OP_geq:
+        case OP_leq:
+        case OP_bit_and:
+        case OP_bit_or:
+        case OP_bit_xor:
+        case OP_log_or:
+        case OP_rshift:
+        case OP_lshift:
+            reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->src0, NULL);
+            reg_idx_src1 = get_src_reg(sym_tbl, ph1_ir->src1, &reg_idx_src0);
+            reg_idx = get_dest_reg(sym_tbl, ph1_ir->dest, i, &reg_idx_src0,
+                                   &reg_idx_src1, 0);
+            ph2_ir = add_ph2_ir(ph1_ir->op);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->src1 = reg_idx_src1;
+            ph2_ir->dest = reg_idx;
+            break;
+        /* workaround: see details at the codegen of OP_log_and */
+        case OP_log_and:
+            reg_idx_src0 = get_src_reg(sym_tbl, ph1_ir->src0, NULL);
+            reg_idx_src1 = get_src_reg(sym_tbl, ph1_ir->src1, &reg_idx_src0);
+            reg_idx = get_dest_reg(sym_tbl, ph1_ir->dest, i, &reg_idx_src0,
+                                   &reg_idx_src1, 1);
+            ph2_ir = add_ph2_ir(ph1_ir->op);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->src1 = reg_idx_src1;
+            ph2_ir->dest = reg_idx;
+            break;
+        default:
+            add_ph2_ir(ph1_ir->op);
+            break;
+        }
+    }
+
+    dump_ph2_ir();
+
+    /* calculate the offset of label */
+    elf_code_idx = 92; /* 72 + 20 */
+    int block_lv = 0;
+    for (i = 0; i < ph2_ir_idx; i++) {
+        ph2_ir = &PH2_IR[i];
+
+        switch (ph2_ir->op) {
+        case OP_define:
+            fn = find_func(ph2_ir->func_name);
+            strcpy(LABEL_LUT[label_lut_idx].name, ph2_ir->func_name);
+            LABEL_LUT[label_lut_idx].offset = elf_code_idx;
+            label_lut_idx++;
+            elf_code_idx += 12;
+            break;
+        case OP_block_start:
+            block_lv++;
+            break;
+        case OP_block_end:
+            if (--block_lv != 0)
+                break;
+            if (!strcmp(fn->return_def.type_name, "void"))
+                elf_code_idx += 16;
+            break;
+        case OP_label:
+            strcpy(LABEL_LUT[label_lut_idx].name, ph2_ir->func_name);
+            LABEL_LUT[label_lut_idx].offset = elf_code_idx;
+            label_lut_idx++;
+            break;
+        case OP_assign:
+        case OP_store:
+        case OP_load:
+        case OP_global_load:
+        case OP_global_store:
+        case OP_global_addr_of:
+        case OP_branch:
+        case OP_jump:
+        case OP_call:
+        case OP_read:
+        case OP_write:
+        case OP_negate:
+        case OP_add:
+        case OP_sub:
+        case OP_mul:
+        case OP_div:
+        case OP_gt:
+        case OP_lt:
+        case OP_bit_and:
+        case OP_bit_or:
+        case OP_bit_xor:
+        case OP_bit_not:
+        case OP_rshift:
+        case OP_lshift:
+        case OP_address_of:
+            elf_code_idx += 4;
+            break;
+        case OP_load_constant:
+        case OP_load_data_address:
+        case OP_neq:
+        case OP_geq:
+        case OP_leq:
+        case OP_log_or:
+        case OP_log_not:
+            elf_code_idx += 8;
+            break;
+        case OP_eq:
+            elf_code_idx += 12;
+            break;
+        case OP_log_and:
+            elf_code_idx += 16;
+            break;
+        case OP_return:
+            elf_code_idx += 20;
+            break;
+        default:
+            break;
+        }
+    }
+
+    int elf_data_start = elf_code_start + elf_code_idx;
+    block_lv = 0;
+    elf_code_idx = 0;
+
+    /* manually insert the entry, exit and syscall */
+    elf_add_symbol("__start", strlen("__start"), 0);
+    emit(__addi(__sp, __sp, -global_syms->stack_size - 4));
+    emit(__sw(__gp, __sp, global_syms->stack_size));
+    emit(__addi(__gp, __sp, 0));
+    emit(__lw(__a0, __sp, 0));   /* argc */
+    emit(__addi(__a1, __sp, 4)); /* argv */
+    for (i = 0; i < label_lut_idx; i++)
+        if (!strcmp(LABEL_LUT[i].name, "main")) {
+            emit(__jal(__ra, LABEL_LUT[i].offset - elf_code_idx));
+            break;
+        }
+
+    elf_add_symbol("__exit", strlen("__exit"), elf_code_idx);
+    emit(__lw(__gp, __sp, global_syms->stack_size));
+    emit(__addi(__sp, __sp, global_syms->stack_size + 4));
+    emit(__addi(__a0, __a0, 0));
+    emit(__addi(__a7, __zero, 93));
+    emit(__ecall());
+
+    elf_add_symbol("__syscall", strlen("__syscall"), elf_code_idx);
+    emit(__addi(__sp, __sp, -8));
+    emit(__sw(__ra, __sp, 0));
+    emit(__sw(__s0, __sp, 4));
+    emit(__addi(__a7, __a0, 0));
+    emit(__addi(__a0, __a1, 0));
+    emit(__addi(__a1, __a2, 0));
+    emit(__addi(__a2, __a3, 0));
+    emit(__ecall());
+    emit(__lw(__s0, __sp, 4));
+    emit(__lw(__ra, __sp, 0));
+    emit(__addi(__sp, __sp, 8));
+    emit(__jalr(__zero, __ra, 0));
+
+    for (i = 0; i < ph2_ir_idx; i++) {
+        ph2_ir = &PH2_IR[i];
+
+        switch (ph2_ir->op) {
+        case OP_define:
+            fn = find_func(ph2_ir->func_name);
+            sym_tbl = find_sym_tbl(fn);
+            emit(__addi(__sp, __sp, -sym_tbl->stack_size - 8));
+            emit(__sw(__ra, __sp, sym_tbl->stack_size));
+            emit(__sw(__s0, __sp, sym_tbl->stack_size + 4));
+            break;
+        case OP_block_start:
+            block_lv++;
+            break;
+        case OP_block_end:
+            if (--block_lv != 0)
+                break;
+            if (!strcmp(fn->return_def.type_name, "void")) {
+                emit(__lw(__s0, __sp, sym_tbl->stack_size + 4));
+                emit(__lw(__ra, __sp, sym_tbl->stack_size));
+                emit(__addi(__sp, __sp, sym_tbl->stack_size + 8));
+                emit(__jalr(__zero, __ra, 0));
+            }
+            break;
+        case OP_load_constant:
+            if (ph2_ir->src0 > -2048 && ph2_ir->src0 < 2047) {
+                emit(__addi(__zero, __zero, 0));
+                emit(__addi(ph2_ir->dest + 10, __zero, ph2_ir->src0));
+            } else {
+                emit(__lui(ph2_ir->dest + 10, rv_hi(ph2_ir->src0)));
+                emit(__addi(ph2_ir->dest + 10, ph2_ir->dest + 10,
+                            rv_lo(ph2_ir->src0)));
+            }
+            break;
+        case OP_load_data_address:
+            emit(
+                __lui(ph2_ir->dest + 10, rv_hi(ph2_ir->src0 + elf_data_start)));
+            emit(__addi(ph2_ir->dest + 10, ph2_ir->dest + 10,
+                        rv_lo(ph2_ir->src0 + elf_data_start)));
+            break;
+        case OP_address_of:
+            emit(__addi(ph2_ir->dest + 10, __sp, ph2_ir->src0));
+            break;
+        case OP_assign:
+            emit(__addi(ph2_ir->dest + 10, ph2_ir->src0 + 10, 0));
+            break;
+        case OP_branch:
+            for (j = 0; j < label_lut_idx; j++)
+                if (!strcmp(LABEL_LUT[j].name, ph2_ir->false_label)) {
+                    ofs = LABEL_LUT[j].offset;
+                    break;
+                }
+            emit(__beq(ph2_ir->src0 + 10, __zero, ofs - elf_code_idx));
+            break;
+        case OP_jump:
+            for (j = 0; j < label_lut_idx; j++)
+                if (!strcmp(LABEL_LUT[j].name, ph2_ir->func_name)) {
+                    ofs = LABEL_LUT[j].offset;
+                    break;
+                }
+            emit(__jal(__zero, ofs - elf_code_idx));
+            break;
+        case OP_load:
+            emit(__lw(ph2_ir->dest + 10, __sp, ph2_ir->src0));
+            break;
+        case OP_store:
+            emit(__sw(ph2_ir->src0 + 10, __sp, ph2_ir->src1));
+            break;
+        case OP_global_load:
+            emit(__lw(ph2_ir->dest + 10, __gp, ph2_ir->src0));
+            break;
+        case OP_global_store:
+            emit(__sw(ph2_ir->src0 + 10, __gp, ph2_ir->src1));
+            break;
+        case OP_global_addr_of:
+            emit(__addi(ph2_ir->dest + 10, __gp, ph2_ir->src0));
+            break;
+        case OP_read:
+            if (ph2_ir->src1 == 1)
+                emit(__lbu(ph2_ir->dest + 10, ph2_ir->src0 + 10, 0));
+            else if (ph2_ir->src1 == 4)
+                emit(__lw(ph2_ir->dest + 10, ph2_ir->src0 + 10, 0));
+            else
+                abort();
+            break;
+        case OP_write:
+            if (ph2_ir->dest == 1)
+                emit(__sb(ph2_ir->src0 + 10, ph2_ir->src1 + 10, 0));
+            else if (ph2_ir->dest == 4)
+                emit(__sw(ph2_ir->src0 + 10, ph2_ir->src1 + 10, 0));
+            else
+                abort();
+            break;
+        case OP_call:
+            for (j = 0; j < label_lut_idx; j++)
+                if (!strcmp(LABEL_LUT[j].name, ph2_ir->func_name)) {
+                    ofs = LABEL_LUT[j].offset;
+                    break;
+                }
+            emit(__jal(__ra, ofs - elf_code_idx));
+            break;
+        case OP_return:
+            if (ph2_ir->src0 == -1)
+                emit(__addi(__zero, __zero, 0));
+            else
+                emit(__addi(__a0, ph2_ir->src0 + 10, 0));
+            emit(__lw(__s0, __sp, sym_tbl->stack_size + 4));
+            emit(__lw(__ra, __sp, sym_tbl->stack_size));
+            emit(__addi(__sp, __sp, sym_tbl->stack_size + 8));
+            emit(__jalr(__zero, __ra, 0));
+            break;
+        case OP_negate:
+            emit(__sub(ph2_ir->dest + 10, __zero, ph2_ir->src0 + 10));
+            break;
+        case OP_add:
+            emit(
+                __add(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_sub:
+            emit(
+                __sub(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_mul:
+            emit(
+                __mul(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_div:
+            emit(
+                __div(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_eq:
+            emit(
+                __sub(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+            break;
+        case OP_neq:
+            emit(
+                __sub(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            break;
+        case OP_gt:
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src1 + 10, ph2_ir->src0 + 10));
+            break;
+        case OP_lt:
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_geq:
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+            break;
+        case OP_leq:
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src1 + 10, ph2_ir->src0 + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+            break;
+        case OP_bit_and:
+            emit(
+                __and(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_bit_or:
+            emit(__or(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_bit_xor:
+            emit(
+                __xor(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_bit_not:
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->src0 + 10, -1));
+            break;
+        /* workaround for the logical-and (&&) operation */
+        case OP_log_and:
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->src0 + 10));
+            emit(__sub(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            emit(
+                __and(ph2_ir->dest + 10, ph2_ir->dest + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            break;
+        case OP_log_or:
+            emit(__or(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            break;
+        case OP_log_not:
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->src0 + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+            break;
+        case OP_rshift:
+            emit(
+                __sra(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        case OP_lshift:
+            emit(
+                __sll(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            break;
+        default:
+            break;
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces the newly two-phase IR to replace the original IR that that is similar to the stack machine. The first phase of the IR is architecture-independent and disassembles the expressions to the three-address-code (3AC) that could help us to add the rules for optimization more easily. The second phase of the IR stores the information produced by the register allocation that using the linear-scanning, and the main purpose of it is to calculate the exact address of the symbols. like the jumping destination or the content in the .data section in the elf.

### Usage
1. Build
    ```shell
    $ make config ARCH=riscv
    $ make
    ```
2. Execute
    ```shell
    $ out/shecc <your_file> # options: --dump-ir, -o <out_name>
    ```
    The `--dump-ir` option will dump the both first and second phase of the IR, separated by the "===" line.

### Known issues
1. The mismatching of structure name and alias will cause error when the frontend parsing chaining access.

    The original declaration of `block_meta_t` in `lib/c.c` has the different name and alias. The `find_type()` function only searches for its alias, not the name. The error will occur when we try to access the member of `*next` pointing to.

2. The control flow is not handled well. Every time encountering the calling or jumping, it spills the registers to ensure the consistence between them. ~~Ideally, it should only need to spill the **poison** ones and drop the unused ones~~ (updated in 98a8ac1).

4. Extend the liveness of the variables to the loop end might cause the inefficient allocation.

5. Only support the RISC-V.