### PR TITLE
Improve IR and register allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 CC ?= gcc
 CFLAGS := -O -g \
 	-ansi -pedantic \
-	-Wall -Wextra
+	-Wall -Wextra \
+	-Wno-maybe-uninitialized
 
 include mk/common.mk
 include mk/arm.mk

--- a/src/cfront.c
+++ b/src/cfront.c
@@ -112,6 +112,40 @@ char token_str[MAX_TOKEN_LEN];
 token_t next_token;
 char next_char;
 
+int global_var_idx = 0;
+int global_label_idx = 0;
+char global_str_buf[MAX_VAR_LEN];
+
+char *gen_name()
+{
+    sprintf(global_str_buf, ".t%d", global_var_idx++);
+    return global_str_buf;
+}
+
+char *gen_label()
+{
+    sprintf(global_str_buf, ".label.%d", global_label_idx++);
+    return global_str_buf;
+}
+
+var_t *require_var(block_t *blk)
+{
+    return &blk->locals[blk->next_local++];
+}
+
+var_t *operand_stack[20];
+int operand_stack_idx = 0;
+
+void opstack_push(var_t *var)
+{
+    operand_stack[operand_stack_idx++] = var;
+}
+
+var_t *opstack_pop()
+{
+    return operand_stack[--operand_stack_idx];
+}
+
 void skip_whitespace()
 {
     while (is_whitespace(next_char))
@@ -537,7 +571,7 @@ void lex_expect(token_t token)
     next_token = get_next_token();
 }
 
-void read_expr(int param_no, block_t *parent);
+void read_expr(block_t *parent);
 
 int write_symbol(char *data, int len)
 {
@@ -552,9 +586,6 @@ int get_size(var_t *var, type_t *type)
         return PTR_SIZE;
     return type->size;
 }
-
-int break_level;
-int continue_level;
 
 int read_numeric_constant(char buffer[])
 {
@@ -580,9 +611,9 @@ int read_numeric_constant(char buffer[])
     return value;
 }
 
-int read_parameter_list_decl(var_t vds[], int anon);
+void read_parameter_list_decl(func_t *fd, int anon);
 
-void read_inner_var_decl(var_t *vd, int anon)
+void read_inner_var_decl(var_t *vd, int anon, int is_param)
 {
     vd->init_val = 0;
     if (lex_accept(T_asterisk))
@@ -592,15 +623,27 @@ void read_inner_var_decl(var_t *vd, int anon)
 
     /* is it function pointer declaration? */
     if (lex_accept(T_open_bracket)) {
-        var_t funargs[MAX_PARAMS];
+        func_t func;
         lex_expect(T_asterisk);
         lex_ident(T_identifier, vd->var_name);
         lex_expect(T_close_bracket);
-        read_parameter_list_decl(funargs, 1);
+        read_parameter_list_decl(&func, 1);
         vd->is_func = 1;
     } else {
-        if (anon == 0)
+        if (anon == 0) {
             lex_ident(T_identifier, vd->var_name);
+            if (!lex_peek(T_open_bracket, NULL) && !is_param) {
+                if (vd->is_global) {
+                    ph1_ir_t *ir = add_global_ir(OP_allocat);
+                    ir->src0 = vd;
+                    opstack_push(vd);
+                } else {
+                    ph1_ir_t *ph1_ir;
+                    ph1_ir = add_ph1_ir(OP_allocat);
+                    ph1_ir->src0 = vd;
+                }
+            }
+        }
         if (lex_accept(T_open_square)) {
             char buffer[10];
 
@@ -623,68 +666,68 @@ void read_inner_var_decl(var_t *vd, int anon)
 }
 
 /* starting next_token, need to check the type */
-void read_full_var_decl(var_t *vd, int anon)
+void read_full_var_decl(var_t *vd, int anon, int is_param)
 {
     lex_accept(T_struct); /* ignore struct definition */
     lex_ident(T_identifier, vd->type_name);
-    read_inner_var_decl(vd, anon);
+    read_inner_var_decl(vd, anon, is_param);
 }
 
 /* starting next_token, need to check the type */
 void read_partial_var_decl(var_t *vd, var_t *template)
 {
     strcpy(vd->type_name, template->type_name);
-    read_inner_var_decl(vd, 0);
+    read_inner_var_decl(vd, 0, 0);
 }
 
-int read_parameter_list_decl(var_t vds[], int anon)
+void read_parameter_list_decl(func_t *fd, int anon)
 {
     int vn = 0;
     lex_expect(T_open_bracket);
     while (lex_peek(T_identifier, NULL) == 1) {
-        read_full_var_decl(&vds[vn++], anon);
+        read_full_var_decl(&fd->param_defs[vn++], anon, 1);
         lex_accept(T_comma);
     }
     if (lex_accept(T_elipsis)) {
-        /* variadic function. Max 8 parameters are passed.
-         * create dummy parameters to put all on stack
-         */
-        for (; vn < MAX_PARAMS; vn++) {
-            strcpy(vds[vn].type_name, "int");
-            strcpy(vds[vn].var_name, "var_arg");
-            vds[vn].is_ptr = 1;
-        }
+        /* variadic function. Max 8 parameters are passed. */
+        fd->va_args = 1;
+        vn = 8;
     }
     lex_expect(T_close_bracket);
-    return vn;
+    fd->num_params = vn;
 }
 
-void read_literal_param(int param_no)
+void read_literal_param(block_t *parent)
 {
-    char literal[MAX_TOKEN_LEN];
-    ir_instr_t *ii;
+    ph1_ir_t *ph1_ir;
+    var_t *vd;
     int index;
+    char literal[MAX_TOKEN_LEN];
 
     lex_ident(T_string, literal);
-
     index = write_symbol(literal, strlen(literal) + 1);
-    ii = add_instr(OP_load_data_address);
-    ii->param_no = param_no;
-    ii->int_param1 = index;
+
+    ph1_ir = add_ph1_ir(OP_load_data_address);
+    vd = require_var(parent);
+    strcpy(vd->var_name, gen_name());
+    vd->init_val = index;
+    ph1_ir->dest = vd;
+    opstack_push(vd);
 }
 
-void read_numeric_param(int param_no, int isneg)
+void read_numeric_param(block_t *parent, int is_neg)
 {
+    ph1_ir_t *ph1_ir;
+    var_t *vd;
     char token[MAX_ID_LEN];
     int value = 0;
     int i = 0;
-    ir_instr_t *ii;
     char c;
 
     lex_ident(T_numeric, token);
 
     if (token[0] == '-') {
-        isneg = 1 - isneg;
+        is_neg = 1 - is_neg;
         i++;
     }
     if ((token[0] == '0') && (token[1] == 'x')) { /* hexadecimal */
@@ -710,108 +753,95 @@ void read_numeric_param(int param_no, int isneg)
         } while (is_digit(token[i]));
     }
 
-    ii = add_instr(OP_load_constant);
-    ii->param_no = param_no;
-    if (isneg)
+    if (is_neg)
         value = -value;
-    ii->int_param1 = value;
+
+    ph1_ir = add_ph1_ir(OP_load_constant);
+    vd = require_var(parent);
+    vd->init_val = value;
+    strcpy(vd->var_name, gen_name());
+    ph1_ir->dest = vd;
+    opstack_push(vd);
 }
 
-void read_char_param(int param_no)
+void read_char_param(block_t *parent)
 {
-    ir_instr_t *ii;
     char token[5];
+    ph1_ir_t *ph1_ir;
+    var_t *vd;
 
     lex_ident(T_char, token);
 
-    ii = add_instr(OP_load_constant);
-    ii->param_no = param_no;
-    ii->int_param1 = token[0];
+    ph1_ir = add_ph1_ir(OP_load_constant);
+    vd = require_var(parent);
+    vd->init_val = token[0];
+    strcpy(vd->var_name, gen_name());
+    ph1_ir->dest = vd;
+    opstack_push(vd);
 }
 
-void read_ternary_operation(int dest, block_t *parent);
+void read_ternary_operation(block_t *parent);
 void read_func_parameters(block_t *parent)
 {
-    int param_num = 0;
+    int i, param_num = 0;
+    var_t *params[MAX_PARAMS];
+
     lex_expect(T_open_bracket);
     while (!lex_accept(T_close_bracket)) {
-        read_expr(param_num++, parent);
-        read_ternary_operation(param_num - 1, parent);
+        read_expr(parent);
+        read_ternary_operation(parent);
+
+        params[param_num++] = opstack_pop();
         lex_accept(T_comma);
     }
-}
-
-ir_instr_t *exit_ii; /* exit for program */
-
-void read_func_call(func_t *fn, int param_no, block_t *parent)
-{
-    ir_instr_t *ii;
-
-    /* already have function name in fn */
-    lex_expect(T_identifier);
-    if (lex_peek(T_open_bracket, NULL)) {
-        /* direct function call */
-        read_func_parameters(parent);
-        ii = add_instr(OP_call);
-        ii->str_param1 = fn->return_def.var_name;
-        ii->param_no = param_no; /* return value here */
-        if (!strcmp(ii->str_param1, "main"))
-            exit_ii->int_param1 = ii->param_no;
-    } else {
-        /* indirect call with function pointer */
-        ii = add_instr(OP_address_of);
-        ii->str_param1 = fn->return_def.var_name;
-        ii->param_no = param_no; /* return value here */
+    for (i = 0; i < param_num; i++) {
+        ph1_ir_t *ph1_ir = add_ph1_ir(OP_push);
+        ph1_ir->src0 = params[i];
     }
 }
 
-void read_indirect_call(int param_no, block_t *parent)
+void read_func_call(func_t *fn, block_t *parent)
 {
-    ir_instr_t *ii;
+    ph1_ir_t *ph1_ir;
 
-    /* preserve existing paremeters */
-    int pn;
-    for (pn = 0; pn < param_no; pn++) {
-        ii = add_instr(OP_push);
-        ii->param_no = pn;
-    }
+    /* direct function call */
+    read_func_parameters(parent);
 
-    /* remember address on stack */
-    ii = add_instr(OP_push);
-    ii->param_no = param_no;
+    ph1_ir = add_ph1_ir(OP_call);
+    ph1_ir->param_num = fn->num_params;
+    strcpy(ph1_ir->func_name, fn->return_def.var_name);
+}
+
+void read_indirect_call(block_t *parent)
+{
+    ph1_ir_t *ph1_ir;
 
     read_func_parameters(parent);
 
-    /* retrieve address from stack into last parameter */
-    ii = add_instr(OP_pop);
-    ii->param_no = MAX_PARAMS - 1;
-
-    ii = add_instr(OP_indirect);
-    ii->int_param1 = MAX_PARAMS - 1; /* register with address */
-    ii->param_no = param_no;         /* return value here */
-
-    /* restore existing parameters */
-    for (pn = param_no - 1; pn >= 0; pn--) {
-        ii = add_instr(OP_pop);
-        ii->param_no = pn;
-    }
+    ph1_ir = add_ph1_ir(OP_indirect);
+    ph1_ir->src0 = opstack_pop();
 }
+
+ph1_ir_t side_effect[10];
+int se_idx = 0;
 
 void read_lvalue(lvalue_t *lvalue,
                  var_t *var,
                  block_t *parent,
-                 int param_no,
                  int eval,
                  opcode_t op);
 
 /* Maintain a stack of expression values and operators, depending on next
  * operators' priority. Either apply it or operator on stack first.
  */
-void read_expr_operand(int param_no, block_t *parent)
+void read_expr_operand(block_t *parent)
 {
-    int isneg = 0;
+    ph1_ir_t *ph1_ir;
+    var_t *vd;
+    int is_neg = 0;
+
     if (lex_accept(T_minus)) {
-        isneg = 1;
+        is_neg = 1;
         if (lex_peek(T_numeric, NULL) == 0 &&
             lex_peek(T_identifier, NULL) == 0 &&
             lex_peek(T_open_bracket, NULL) == 0) {
@@ -820,21 +850,29 @@ void read_expr_operand(int param_no, block_t *parent)
     }
 
     if (lex_peek(T_string, NULL))
-        read_literal_param(param_no);
+        read_literal_param(parent);
     else if (lex_peek(T_char, NULL))
-        read_char_param(param_no);
+        read_char_param(parent);
     else if (lex_peek(T_numeric, NULL))
-        read_numeric_param(param_no, isneg);
+        read_numeric_param(parent, is_neg);
     else if (lex_accept(T_log_not)) {
-        ir_instr_t *ii;
-        read_expr_operand(param_no, parent);
-        ii = add_instr(OP_log_not);
-        ii->param_no = param_no;
+        read_expr_operand(parent);
+
+        ph1_ir = add_ph1_ir(OP_log_not);
+        ph1_ir->src0 = opstack_pop();
+        vd = require_var(parent);
+        strcpy(vd->var_name, gen_name());
+        ph1_ir->dest = vd;
+        opstack_push(vd);
     } else if (lex_accept(T_bit_not)) {
-        ir_instr_t *ii;
-        read_expr_operand(param_no, parent);
-        ii = add_instr(OP_bit_not);
-        ii->param_no = param_no;
+        read_expr_operand(parent);
+
+        ph1_ir = add_ph1_ir(OP_bit_not);
+        ph1_ir->src0 = opstack_pop();
+        vd = require_var(parent);
+        strcpy(vd->var_name, gen_name());
+        ph1_ir->dest = vd;
+        opstack_push(vd);
     } else if (lex_accept(T_ampersand)) {
         char token[MAX_VAR_LEN];
         var_t *var;
@@ -842,35 +880,44 @@ void read_expr_operand(int param_no, block_t *parent)
 
         lex_peek(T_identifier, token);
         var = find_var(token, parent);
-        read_lvalue(&lvalue, var, parent, param_no, 0, OP_generic);
+        read_lvalue(&lvalue, var, parent, 0, OP_generic);
+
+        if (lvalue.is_reference == 0) {
+            ph1_ir = add_ph1_ir(OP_address_of);
+            ph1_ir->src0 = opstack_pop();
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
+        }
     } else if (lex_accept(T_asterisk)) {
         /* dereference */
         char token[MAX_VAR_LEN];
         var_t *var;
         lvalue_t lvalue;
-        ir_instr_t *ii;
 
         lex_accept(T_open_bracket);
         lex_peek(T_identifier, token);
         var = find_var(token, parent);
-        read_lvalue(&lvalue, var, parent, param_no, 1, OP_generic);
+        read_lvalue(&lvalue, var, parent, 1, OP_generic);
         lex_accept(T_close_bracket);
-        ii = add_instr(OP_read);
-        ii->param_no = param_no;
-        ii->int_param1 = param_no;
-        ii->int_param2 = lvalue.size;
-    } else if (lex_accept(T_open_bracket)) {
-        read_expr(param_no, parent);
-        lex_expect(T_close_bracket);
 
-        if (isneg) {
-            ir_instr_t *ii = add_instr(OP_negate);
-            ii->param_no = param_no;
-        }
+        ph1_ir = add_ph1_ir(OP_read);
+        ph1_ir->src0 = opstack_pop();
+        vd = require_var(parent);
+        if (lvalue.is_ptr > 1)
+            ph1_ir->size = PTR_SIZE;
+        else
+            ph1_ir->size = lvalue.size;
+        strcpy(vd->var_name, gen_name());
+        ph1_ir->dest = vd;
+        opstack_push(vd);
+    } else if (lex_accept(T_open_bracket)) {
+        read_expr(parent);
+        lex_expect(T_close_bracket);
     } else if (lex_accept(T_sizeof)) {
         char token[MAX_TYPE_LEN];
         type_t *type;
-        ir_instr_t *ii = add_instr(OP_load_constant);
 
         lex_expect(T_open_bracket);
         lex_ident(T_identifier, token);
@@ -878,8 +925,12 @@ void read_expr_operand(int param_no, block_t *parent)
         if (!type)
             error("Unable to find type");
 
-        ii->param_no = param_no;
-        ii->int_param1 = type->size;
+        ph1_ir = add_ph1_ir(OP_load_constant);
+        vd = require_var(parent);
+        vd->init_val = type->size;
+        strcpy(vd->var_name, gen_name());
+        ph1_ir->dest = vd;
+        opstack_push(vd);
         lex_expect(T_close_bracket);
     } else {
         /* function call, constant or variable - read token and determine */
@@ -902,34 +953,45 @@ void read_expr_operand(int param_no, block_t *parent)
         fn = find_func(token);
 
         if (con) {
-            int value = con->value;
-            ir_instr_t *ii = add_instr(OP_load_constant);
-            ii->param_no = param_no;
-            ii->int_param1 = value;
+            ph1_ir = add_ph1_ir(OP_load_constant);
+            vd = require_var(parent);
+            vd->init_val = con->value;
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
             lex_expect(T_identifier);
         } else if (var) {
             /* evalue lvalue expression */
             lvalue_t lvalue;
-            read_lvalue(&lvalue, var, parent, param_no, 1, prefix_op);
+            read_lvalue(&lvalue, var, parent, 1, prefix_op);
+
             /* is it an indirect call with function pointer? */
-            if (lex_peek(T_open_bracket, NULL))
-                read_indirect_call(param_no, parent);
-        } else if (fn) {
-            ir_instr_t *ii;
-            int pn;
-            for (pn = 0; pn < param_no; pn++) {
-                ii = add_instr(OP_push);
-                ii->param_no = pn;
+            if (lex_peek(T_open_bracket, NULL)) {
+                read_indirect_call(parent);
+
+                ph1_ir = add_ph1_ir(OP_func_ret);
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
             }
+        } else if (fn) {
+            lex_expect(T_identifier);
 
-            /* we should push existing parameters onto the stack since
-             * function calls use the same.
-             */
-            read_func_call(fn, param_no, parent);
+            if (lex_peek(T_open_bracket, NULL)) {
+                read_func_call(fn, parent);
 
-            for (pn = param_no - 1; pn >= 0; pn--) {
-                ii = add_instr(OP_pop);
-                ii->param_no = pn;
+                ph1_ir = add_ph1_ir(OP_func_ret);
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
+            } else {
+                /* indirective function pointer assignment */
+                vd = require_var(parent);
+                vd->is_func = 1;
+                strcpy(vd->var_name, token);
+                opstack_push(vd);
             }
         } else {
             printf("%s\n", token);
@@ -937,9 +999,13 @@ void read_expr_operand(int param_no, block_t *parent)
             error("Unrecognized expression token");
         }
 
-        if (isneg) {
-            ir_instr_t *ii = add_instr(OP_negate);
-            ii->param_no = param_no;
+        if (is_neg) {
+            ph1_ir = add_ph1_ir(OP_negate);
+            ph1_ir->src0 = opstack_pop();
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
         }
     }
 }
@@ -1024,116 +1090,57 @@ opcode_t get_operator()
     return op;
 }
 
-void read_expr(int param_no, block_t *parent)
+void read_expr(block_t *parent)
 {
-    opcode_t op_stack[10];
-    int op_stack_index = 0;
-    opcode_t op, next_op;
-    ir_instr_t *il;
+    ph1_ir_t *ph1_ir;
+    var_t *vd;
+    opcode_t op;
+    opcode_t oper_stack[10];
+    int oper_stack_idx = 0;
 
-    /* read value into param_no */
-    read_expr_operand(param_no, parent);
+    read_expr_operand(parent);
 
-    /* check for any operator following */
     op = get_operator();
-    if (op == OP_generic || op == OP_ternary) /* no continuation */
+    if (op == OP_generic || op == OP_ternary)
         return;
 
-    read_expr_operand(param_no + 1, parent);
-    next_op = get_operator();
-
-    if (next_op == OP_generic || op == OP_ternary) {
-        /* only two operands, apply and return */
-        il = add_instr(op);
-        il->param_no = param_no;
-        il->int_param1 = param_no + 1;
-        return;
-    }
-
-    /* if more than two operands, then use stack */
-    il = add_instr(OP_push);
-    il->param_no = param_no;
-    il = add_instr(OP_push);
-    il->param_no = param_no + 1;
-    op_stack[0] = op;
-    op_stack_index++;
-    op = next_op;
+    oper_stack[oper_stack_idx++] = op;
+    read_expr_operand(parent);
+    op = get_operator();
 
     while (op != OP_generic && op != OP_ternary) {
-        /* if we have operand on stack, compare priorities */
-        if (op_stack_index > 0) {
-            /* we have a continuation, use stack */
-            int same_op = 0;
+        if (oper_stack_idx > 0) {
+            int same = 0;
             do {
-                opcode_t stack_op = op_stack[op_stack_index - 1];
-                if (get_operator_prio(stack_op) >= get_operator_prio(op)) {
-                    /* stack has higher priority operator i.e. 5 * 6 + _
-                     * pop stack and apply operators.
-                     */
-                    il = add_instr(OP_pop);
-                    il->param_no = param_no + 1;
+                opcode_t top_op = oper_stack[oper_stack_idx - 1];
+                if (get_operator_prio(top_op) >= get_operator_prio(op)) {
+                    ph1_ir = add_ph1_ir(top_op);
+                    ph1_ir->src1 = opstack_pop();
+                    ph1_ir->src0 = opstack_pop();
+                    vd = require_var(parent);
+                    strcpy(vd->var_name, gen_name());
+                    ph1_ir->dest = vd;
+                    opstack_push(vd);
 
-                    il = add_instr(OP_pop);
-                    il->param_no = param_no;
-
-                    /* apply stack operator  */
-                    il = add_instr(stack_op);
-                    il->param_no = param_no;
-                    il->int_param1 = param_no + 1;
-
-                    /* push value back on stack */
-                    il = add_instr(OP_push);
-                    il->param_no = param_no;
-
-                    /* pop op stack */
-                    op_stack_index--;
-                } else {
-                    same_op = 1;
-                }
-                /* continue util next operation is higher prio, i.e. 5 + 6 * _
-                 */
-            } while (op_stack_index > 0 && same_op == 0);
+                    oper_stack_idx--;
+                } else
+                    same = 1;
+            } while (oper_stack_idx > 0 && same == 0);
         }
-
-        /* push operator on stack */
-        op_stack[op_stack_index++] = op;
-
-        /* push value on stack */
-        read_expr_operand(param_no, parent);
-        il = add_instr(OP_push);
-        il->param_no = param_no;
-
+        read_expr_operand(parent);
+        oper_stack[oper_stack_idx++] = op;
         op = get_operator();
     }
 
-    /* unwind stack and apply operations */
-    while (op_stack_index > 0) {
-        opcode_t stack_op = op_stack[op_stack_index - 1];
-
-        /* pop stack and apply operators */
-        il = add_instr(OP_pop);
-        il->param_no = param_no + 1;
-
-        il = add_instr(OP_pop);
-        il->param_no = param_no;
-
-        /* apply stack operator  */
-        il = add_instr(stack_op);
-        il->param_no = param_no;
-        il->int_param1 = param_no + 1;
-
-        if (op_stack_index == 1) /* done */
-            return;
-
-        /* push value back on stack */
-        il = add_instr(OP_push);
-        il->param_no = param_no;
-
-        /* pop op stack */
-        op_stack_index--;
+    while (oper_stack_idx > 0) {
+        ph1_ir = add_ph1_ir(oper_stack[--oper_stack_idx]);
+        ph1_ir->src1 = opstack_pop();
+        ph1_ir->src0 = opstack_pop();
+        vd = require_var(parent);
+        strcpy(vd->var_name, gen_name());
+        ph1_ir->dest = vd;
+        opstack_push(vd);
     }
-
-    error("Unexpected end of expression");
 }
 
 /* Return the address that an expression points to, or evaluate its value.
@@ -1145,78 +1152,98 @@ void read_expr(int param_no, block_t *parent)
 void read_lvalue(lvalue_t *lvalue,
                  var_t *var,
                  block_t *parent,
-                 int param_no,
                  int eval,
                  opcode_t prefix_op)
 {
-    ir_instr_t *ii;
-    int is_reference = 1;
+    ph1_ir_t *ph1_ir;
+    var_t *vd;
+    int is_address_got = 0;
+    int is_member = 0;
 
     /* already peeked and have the variable */
     lex_expect(T_identifier);
 
-    /* load memory location into param */
-    ii = add_instr(OP_address_of);
-    ii->param_no = param_no;
-    ii->str_param1 = var->var_name;
     lvalue->type = find_type(var->type_name);
     lvalue->size = get_size(var, lvalue->type);
     lvalue->is_ptr = var->is_ptr;
-    if (var->array_size > 0)
-        is_reference = 0;
+    lvalue->is_func = var->is_func;
+    lvalue->is_reference = 0;
+
+    opstack_push(var);
+
+    if (lex_peek(T_open_square, NULL) || lex_peek(T_arrow, NULL) ||
+        lex_peek(T_dot, NULL))
+        lvalue->is_reference = 1;
 
     while (lex_peek(T_open_square, NULL) || lex_peek(T_arrow, NULL) ||
            lex_peek(T_dot, NULL)) {
         if (lex_accept(T_open_square)) {
-            is_reference = 1;
-            if (var->is_ptr <= 1) /* if nested pointer, still pointer */
-                lvalue->size = lvalue->type->size;
-
-            /* offset, so var must be either a pointer or an array of some type
-             */
+            /* var must be either a pointer or an array of some type */
             if (var->is_ptr == 0 && var->array_size == 0)
                 error("Cannot apply square operator to non-pointer");
+            /* if nested pointer, still pointer */
+            if (var->is_ptr <= 1 && var->array_size == 0)
+                lvalue->size = lvalue->type->size;
 
-            /* if var is an array, the memory location points to its start, but
-             * if var is a pointer, we need to dereference.
-             */
-            if (var->is_ptr) {
-                ii = add_instr(OP_read);
-                ii->param_no = param_no;
-                ii->int_param1 = param_no;
-                ii->int_param2 = PTR_SIZE; /* pointer */
-            }
-
-            /* param+1 has the offset in array terms */
-            read_expr(param_no + 1, parent);
+            read_expr(parent);
 
             /* multiply by element size */
             if (lvalue->size != 1) {
-                ii = add_instr(OP_load_constant);
-                ii->int_param1 = lvalue->size;
-                ii->param_no = param_no + 2;
+                ph1_ir = add_ph1_ir(OP_load_constant);
+                vd = require_var(parent);
+                vd->init_val = lvalue->size;
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
 
-                ii = add_instr(OP_mul);
-                ii->param_no = param_no + 1;
-                ii->int_param1 = param_no + 2;
+                ph1_ir = add_ph1_ir(OP_mul);
+                ph1_ir->src1 = opstack_pop();
+                ph1_ir->src0 = opstack_pop();
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
             }
 
-            ii = add_instr(OP_add);
-            ii->param_no = param_no;
-            ii->int_param1 = param_no + 1;
+            ph1_ir = add_ph1_ir(OP_add);
+            ph1_ir->src1 = opstack_pop();
+            ph1_ir->src0 = opstack_pop();
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
 
             lex_expect(T_close_square);
+            is_address_got = 1;
+            is_member = 1;
+            lvalue->is_reference = 1;
         } else {
             char token[MAX_ID_LEN];
 
             if (lex_accept(T_arrow)) {
-                /* dereference first */
-                ii = add_instr(OP_read);
-                ii->param_no = param_no;
-                ii->int_param1 = param_no;
-                ii->int_param2 = PTR_SIZE;
-            } else
+                if (is_member == 1) {
+                    ph1_ir = add_ph1_ir(OP_read);
+                    ph1_ir->src0 = opstack_pop();
+                    vd = require_var(parent);
+                    strcpy(vd->var_name, gen_name());
+                    ph1_ir->dest = vd;
+                    opstack_push(vd);
+                    ph1_ir->size = 4;
+                }
+            } else {
                 lex_expect(T_dot);
+
+                if (is_address_got == 0) {
+                    ph1_ir = add_ph1_ir(OP_address_of);
+                    ph1_ir->src0 = opstack_pop();
+                    vd = require_var(parent);
+                    strcpy(vd->var_name, gen_name());
+                    ph1_ir->dest = vd;
+                    opstack_push(vd);
+
+                    is_address_got = 1;
+                }
+            }
 
             lex_ident(T_identifier, token);
 
@@ -1224,155 +1251,221 @@ void read_lvalue(lvalue_t *lvalue,
             var = find_member(token, lvalue->type);
             lvalue->type = find_type(var->type_name);
             lvalue->is_ptr = var->is_ptr;
-
-            /* reset target */
-            is_reference = 1;
+            lvalue->is_func = var->is_func;
             lvalue->size = get_size(var, lvalue->type);
-            if (var->array_size > 0) {
-                is_reference = 0;
-            }
+
+            if (var->array_size > 0)
+                lvalue->is_reference = 0;
 
             /* move pointer to offset of structure */
-            ii = add_instr(OP_load_constant);
-            ii->int_param1 = var->offset;
-            ii->param_no = param_no + 1;
+            ph1_ir = add_ph1_ir(OP_load_constant);
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            vd->init_val = var->offset;
+            ph1_ir->dest = vd;
+            opstack_push(vd);
 
-            ii = add_instr(OP_add);
-            ii->param_no = param_no;
-            ii->int_param1 = param_no + 1;
+            ph1_ir = add_ph1_ir(OP_add);
+            ph1_ir->src1 = opstack_pop();
+            ph1_ir->src0 = opstack_pop();
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
+
+            is_address_got = 1;
+            is_member = 1;
         }
     }
 
-    if (eval == 0)
+    if (!eval)
         return;
 
-    /* need to apply pointer arithmetic? */
-    if (lex_peek(T_plus, NULL) &&
-        ((var->is_ptr > 0) || (var->array_size > 0))) {
-        lex_accept(T_plus);
-
-        /* dereference if necessary */
-        if (is_reference) {
-            ii = add_instr(OP_read);
-            ii->param_no = param_no;
-            ii->int_param1 = param_no;
-            ii->int_param2 = PTR_SIZE;
-        }
-
-        /* param+1 has the offset in array terms */
-        read_expr_operand(param_no + 1, parent);
-
-        /* shift by offset in type sizes */
-        lvalue->size = lvalue->type->size;
-
-        /* multiply by element size */
-        if (lvalue->size != 1) {
-            ii = add_instr(OP_load_constant);
-            ii->int_param1 = lvalue->size;
-            ii->param_no = param_no + 2;
-
-            ii = add_instr(OP_mul);
-            ii->param_no = param_no + 1;
-            ii->int_param1 = param_no + 2;
-        }
-
-        ii = add_instr(OP_add);
-        ii->param_no = param_no;
-        ii->int_param1 = param_no + 1;
-    } else {
-        /* should NOT dereference if var is of type array and there was
-         * no offset.
-         */
-        if (is_reference) {
-            if (prefix_op != OP_generic) {
-                /* read into (p + 1) */
-                ii = add_instr(OP_read);
-                ii->param_no = param_no + 1;
-                ii->int_param1 = param_no;
-                ii->int_param2 = lvalue->size;
-
-                /* load 1 */
-                ii = add_instr(OP_load_constant);
-                ii->param_no = param_no + 2;
-                ii->int_param1 = 1;
-
-                /* add/sub */
-                ii = add_instr(prefix_op);
-                ii->param_no = param_no + 1;
-                ii->int_param1 = param_no + 2;
-
-                /* store */
-                ii = add_instr(OP_write);
-                ii->param_no = param_no + 1;
-                ii->int_param1 = param_no;
-                ii->int_param2 = lvalue->size;
+    if (lex_peek(T_plus, NULL) && (var->is_ptr || var->array_size)) {
+        while (lex_peek(T_plus, NULL) && (var->is_ptr || var->array_size)) {
+            lex_expect(T_plus);
+            if (lvalue->is_reference) {
+                ph1_ir = add_ph1_ir(OP_read);
+                ph1_ir->src0 = opstack_pop();
+                vd = require_var(parent);
+                ph1_ir->size = lvalue->size;
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
             }
-            if (lex_peek(T_increment, NULL) || lex_peek(T_decrement, NULL)) {
-                /* load value into param_no + 1 */
-                ii = add_instr(OP_read);
-                ii->param_no = param_no + 1;
-                ii->int_param1 = param_no;
-                ii->int_param2 = lvalue->size;
 
-                /* push the value */
-                ii = add_instr(OP_push);
-                ii->param_no = param_no + 1;
+            read_expr_operand(parent);
 
-                /* load 1 */
-                ii = add_instr(OP_load_constant);
-                ii->param_no = param_no + 2;
-                ii->int_param1 = 1;
+            lvalue->size = lvalue->type->size;
 
-                /* add 1 */
-                ii = add_instr(lex_accept(T_increment) ? OP_add : OP_sub);
-                ii->param_no = param_no + 1;
-                ii->int_param1 = param_no + 2;
+            if (lvalue->size > 1) {
+                ph1_ir = add_ph1_ir(OP_load_constant);
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                vd->init_val = lvalue->size;
+                ph1_ir->dest = vd;
+                opstack_push(vd);
 
-                /* store */
-                ii = add_instr(OP_write);
-                ii->param_no = param_no + 1;
-                ii->int_param1 = param_no;
-                ii->int_param2 = lvalue->size;
+                ph1_ir = add_ph1_ir(OP_mul);
+                ph1_ir->src1 = opstack_pop();
+                ph1_ir->src0 = opstack_pop();
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
+            }
 
-                /* pop original  value */
-                ii = add_instr(OP_pop);
-                ii->param_no = param_no;
+            ph1_ir = add_ph1_ir(OP_add);
+            ph1_ir->src1 = opstack_pop();
+            ph1_ir->src0 = opstack_pop();
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
+        }
+    } else {
+        var_t *t;
+        if (lvalue->is_reference) {
+            ph1_ir = add_ph1_ir(OP_read);
+            ph1_ir->src0 = operand_stack[operand_stack_idx - 1];
+            t = require_var(parent);
+            ph1_ir->size = lvalue->size;
+            strcpy(t->var_name, gen_name());
+            ph1_ir->dest = t;
+            opstack_push(t);
+        }
+        if (prefix_op != OP_generic) {
+            ph1_ir = add_ph1_ir(OP_load_constant);
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            vd->init_val = 1;
+            ph1_ir->dest = vd;
+            opstack_push(vd);
+
+            ph1_ir = add_ph1_ir(prefix_op);
+            ph1_ir->src1 = opstack_pop();
+            if (lvalue->is_reference)
+                ph1_ir->src0 = opstack_pop();
+            else
+                ph1_ir->src0 = operand_stack[operand_stack_idx - 1];
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+
+            if (lvalue->is_reference) {
+                ph1_ir = add_ph1_ir(OP_write);
+                ph1_ir->src0 = vd;
+                ph1_ir->dest = opstack_pop();
+                ph1_ir->size = lvalue->size;
             } else {
-                ii = add_instr(OP_read);
-                ii->param_no = param_no;
-                ii->int_param1 = param_no;
-                ii->int_param2 = lvalue->size;
+                ph1_ir = add_ph1_ir(OP_assign);
+                ph1_ir->src0 = vd;
+                ph1_ir->dest = operand_stack[operand_stack_idx - 1];
+            }
+        } else if (lex_peek(T_increment, NULL) || lex_peek(T_decrement, NULL)) {
+            side_effect[se_idx].op = OP_load_constant;
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            vd->init_val = 1;
+            side_effect[se_idx].dest = vd;
+            se_idx++;
+
+            side_effect[se_idx].op = lex_accept(T_increment) ? OP_add : OP_sub;
+            side_effect[se_idx].src1 = vd;
+            if (lvalue->is_reference)
+                side_effect[se_idx].src0 = opstack_pop();
+            else
+                side_effect[se_idx].src0 = operand_stack[operand_stack_idx - 1];
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            side_effect[se_idx].dest = vd;
+            se_idx++;
+
+            if (lvalue->is_reference) {
+                side_effect[se_idx].op = OP_write;
+                side_effect[se_idx].src0 = vd;
+                side_effect[se_idx].dest = opstack_pop();
+                side_effect[se_idx].size = lvalue->size;
+                opstack_push(t);
+                se_idx++;
+            } else {
+                side_effect[se_idx].op = OP_assign;
+                side_effect[se_idx].src0 = vd;
+                side_effect[se_idx].dest = operand_stack[operand_stack_idx - 1];
+                se_idx++;
+            }
+        } else {
+            if (lvalue->is_reference) {
+                t = opstack_pop();
+                opstack_pop();
+                opstack_push(t);
             }
         }
     }
 }
 
-void read_ternary_operation(int dest, block_t *parent)
+void read_ternary_operation(block_t *parent)
 {
-    ir_instr_t *false_jump, *true_jump, *ii;
+    ph1_ir_t *ph1_ir;
+    var_t *vd, *var;
+    char true_label[32], false_label[32], end_label[32];
+
+    strcpy(true_label, gen_label());
+    strcpy(false_label, gen_label());
+    strcpy(end_label, gen_label());
 
     if (!lex_accept(T_question))
         return;
+
     /* ternary-operator */
-    false_jump = add_instr(OP_jz);
-    false_jump->param_no = dest;
+    ph1_ir = add_ph1_ir(OP_branch);
+    ph1_ir->dest = opstack_pop();
+    vd = require_var(parent);
+    strcpy(vd->var_name, true_label);
+    ph1_ir->src0 = vd;
+    vd = require_var(parent);
+    strcpy(vd->var_name, false_label);
+    ph1_ir->src1 = vd;
 
     /* true branch */
-    read_expr(dest, parent);
+    ph1_ir = add_ph1_ir(OP_label);
+    vd = require_var(parent);
+    strcpy(vd->var_name, true_label);
+    ph1_ir->src0 = vd;
+
+    read_expr(parent);
     if (!lex_accept(T_colon))
         return;
 
+    ph1_ir = add_ph1_ir(OP_assign);
+    ph1_ir->src0 = opstack_pop();
+    var = require_var(parent);
+    strcpy(var->var_name, gen_name());
+    ph1_ir->dest = var;
+
     /* jump true branch to end of expression */
-    true_jump = add_instr(OP_jump);
-    ii = add_instr(OP_label);
-    false_jump->int_param1 = ii->ir_index;
+    ph1_ir = add_ph1_ir(OP_jump);
+    vd = require_var(parent);
+    strcpy(vd->var_name, end_label);
+    ph1_ir->dest = vd;
 
     /* false branch */
-    read_expr(dest, parent);
+    ph1_ir = add_ph1_ir(OP_label);
+    vd = require_var(parent);
+    strcpy(vd->var_name, false_label);
+    ph1_ir->src0 = vd;
+    read_expr(parent);
 
-    /* this is finish, link true jump */
-    ii = add_instr(OP_label);
-    true_jump->int_param1 = ii->ir_index;
+    ph1_ir = add_ph1_ir(OP_assign);
+    ph1_ir->src0 = opstack_pop();
+    ph1_ir->dest = var;
+
+    ph1_ir = add_ph1_ir(OP_label);
+    vd = require_var(parent);
+    strcpy(vd->var_name, end_label);
+    ph1_ir->src0 = vd;
+
+    opstack_push(var);
 }
 
 int read_body_assignment(char *token, block_t *parent, opcode_t prefix_op)
@@ -1381,14 +1474,14 @@ int read_body_assignment(char *token, block_t *parent, opcode_t prefix_op)
     if (!var)
         var = find_global_var(token);
     if (var) {
-        ir_instr_t *ii;
+        ph1_ir_t *ph1_ir;
         int one = 0;
         opcode_t op = OP_generic;
         lvalue_t lvalue;
         int size = 0;
 
         /* has memory address that we want to set */
-        read_lvalue(&lvalue, var, parent, 0, 0, OP_generic);
+        read_lvalue(&lvalue, var, parent, 0, OP_generic);
         size = lvalue.size;
 
         if (lex_accept(T_increment)) {
@@ -1406,12 +1499,17 @@ int read_body_assignment(char *token, block_t *parent, opcode_t prefix_op)
         } else if (lex_accept(T_andeq)) {
             op = OP_bit_and;
         } else if (lex_peek(T_open_bracket, NULL)) {
+            var_t *vd;
             /* dereference lvalue into function address */
-            ii = add_instr(OP_read);
-            ii->param_no = 0;
-            ii->int_param1 = 0;
-            ii->int_param2 = lvalue.size;
-            read_indirect_call(0, parent);
+            ph1_ir = add_ph1_ir(OP_read);
+            ph1_ir->src0 = opstack_pop();
+            ph1_ir->size = PTR_SIZE;
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
+
+            read_indirect_call(parent);
             return 1;
         } else if (prefix_op == OP_generic) {
             lex_expect(T_assign);
@@ -1421,54 +1519,116 @@ int read_body_assignment(char *token, block_t *parent, opcode_t prefix_op)
         }
 
         if (op != OP_generic) {
+            var_t *vd, *t;
             int increment_size = 1;
 
             /* if we have a pointer, shift it by element size */
             if (lvalue.is_ptr)
                 increment_size = lvalue.type->size;
 
-            /* get current value into ?1 */
-            ii = add_instr(OP_read);
-            ii->param_no = 1;
-            ii->int_param1 = 0;
-            ii->int_param2 = size;
-
-            /* set ?2 with either 1 or expression value */
             if (one == 1) {
-                ii = add_instr(OP_load_constant);
-                ii->param_no = 2;
-                ii->int_param1 = increment_size;
+                if (lvalue.is_reference) {
+                    ph1_ir = add_ph1_ir(OP_read);
+                    t = opstack_pop();
+                    ph1_ir->src0 = t;
+                    ph1_ir->size = lvalue.size;
+                    vd = require_var(parent);
+                    strcpy(vd->var_name, gen_name());
+                    ph1_ir->dest = vd;
+                    opstack_push(vd);
+                } else
+                    t = operand_stack[operand_stack_idx - 1];
+
+                ph1_ir = add_ph1_ir(OP_load_constant);
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                vd->init_val = increment_size;
+                ph1_ir->dest = vd;
+
+                ph1_ir = add_ph1_ir(op);
+                ph1_ir->src1 = vd;
+                ph1_ir->src0 = opstack_pop();
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+
+                if (lvalue.is_reference) {
+                    ph1_ir = add_ph1_ir(OP_write);
+                    ph1_ir->src0 = vd;
+                    ph1_ir->dest = t;
+                    ph1_ir->size = size;
+                } else {
+                    ph1_ir = add_ph1_ir(OP_assign);
+                    ph1_ir->src0 = vd;
+                    ph1_ir->dest = t;
+                }
             } else {
-                read_expr(2, parent);
+                if (lvalue.is_reference) {
+                    ph1_ir = add_ph1_ir(OP_read);
+                    t = opstack_pop();
+                    ph1_ir->src0 = t;
+                    vd = require_var(parent);
+                    ph1_ir->size = lvalue.size;
+                    strcpy(vd->var_name, gen_name());
+                    ph1_ir->dest = vd;
+                    opstack_push(vd);
+                } else
+                    t = operand_stack[operand_stack_idx - 1];
 
-                /* multiply by element size if necessary */
-                if (increment_size != 1) {
-                    ii = add_instr(OP_load_constant);
-                    ii->param_no = 3;
-                    ii->int_param1 = increment_size;
+                read_expr(parent);
 
-                    ii = add_instr(OP_mul);
-                    ii->param_no = 2;
-                    ii->int_param1 = 3;
+                ph1_ir = add_ph1_ir(OP_load_constant);
+                vd = require_var(parent);
+                vd->init_val = increment_size;
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
+
+                ph1_ir = add_ph1_ir(OP_mul);
+                ph1_ir->src1 = opstack_pop();
+                ph1_ir->src0 = opstack_pop();
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+                opstack_push(vd);
+
+                ph1_ir = add_ph1_ir(op);
+                ph1_ir->src1 = opstack_pop();
+                ph1_ir->src0 = opstack_pop();
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+
+                if (lvalue.is_reference) {
+                    ph1_ir = add_ph1_ir(OP_write);
+                    ph1_ir->src0 = vd;
+                    ph1_ir->dest = t;
+                    ph1_ir->size = lvalue.size;
+                } else {
+                    ph1_ir = add_ph1_ir(OP_assign);
+                    ph1_ir->src0 = vd;
+                    ph1_ir->dest = t;
                 }
             }
-
-            /* apply operation to value in ?1 */
-            ii = add_instr(op);
-            ii->param_no = 1;
-            ii->int_param1 = 2;
         } else {
-            read_expr(1, parent); /* get expression value into ?1 */
+            read_expr(parent);
+            read_ternary_operation(parent);
+
+            if (lvalue.is_func) {
+                ph1_ir = add_ph1_ir(OP_write);
+                ph1_ir->src0 = opstack_pop();
+                ph1_ir->dest = opstack_pop();
+            } else if (lvalue.is_reference) {
+                ph1_ir = add_ph1_ir(OP_write);
+                ph1_ir->src0 = opstack_pop();
+                ph1_ir->dest = opstack_pop();
+                ph1_ir->size = size;
+            } else {
+                ph1_ir = add_ph1_ir(OP_assign);
+                ph1_ir->src0 = opstack_pop();
+                ph1_ir->dest = opstack_pop();
+            }
         }
-
-        read_ternary_operation(1, parent);
-
-        /* store value at specific address, but need to know the type/size */
-        ii = add_instr(OP_write);
-        ii->param_no = 1;
-        ii->int_param1 = 0;
-        ii->int_param2 = size;
-
         return 1;
     }
     return 0;
@@ -1563,6 +1723,10 @@ void eval_ternary_imm(int cond, char *token)
 
 int read_global_assignment(char *token)
 {
+    ph1_ir_t *ph1_ir;
+    var_t *vd;
+    block_t *parent = &BLOCKS[0];
+
     /* global initialization must be constant */
     var_t *var = find_global_var(token);
     if (var) {
@@ -1575,7 +1739,17 @@ int read_global_assignment(char *token)
         op = get_operator();
         /* only one value after assignment */
         if (op == OP_generic) {
-            var->init_val = operand1;
+            ph1_ir = add_global_ir(OP_load_constant);
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            vd->init_val = operand1;
+            ph1_ir->dest = vd;
+
+            ph1_ir = add_global_ir(OP_assign);
+            ph1_ir->src0 = vd;
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = opstack_pop();
             return 1;
         } else if (op == OP_ternary) {
             lex_expect(T_question);
@@ -1586,7 +1760,17 @@ int read_global_assignment(char *token)
         next_op = get_operator();
         if (next_op == OP_generic) {
             /* only two operands, apply and return */
-            var->init_val = eval_expression_imm(op, operand1, operand2);
+            ph1_ir = add_global_ir(OP_load_constant);
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            vd->init_val = eval_expression_imm(op, operand1, operand2);
+            ph1_ir->dest = vd;
+
+            ph1_ir = add_global_ir(OP_assign);
+            ph1_ir->src0 = vd;
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = opstack_pop();
             return 1;
         } else if (op == OP_ternary) {
             int cond;
@@ -1650,7 +1834,17 @@ int read_global_assignment(char *token)
                     lex_expect(T_question);
                     eval_ternary_imm(val_stack[0], token);
                 } else {
-                    var->init_val = val_stack[0];
+                    ph1_ir = add_global_ir(OP_load_constant);
+                    vd = require_var(parent);
+                    strcpy(vd->var_name, gen_name());
+                    vd->init_val = val_stack[0];
+                    ph1_ir->dest = vd;
+
+                    ph1_ir = add_global_ir(OP_assign);
+                    ph1_ir->src0 = vd;
+                    vd = require_var(parent);
+                    strcpy(vd->var_name, gen_name());
+                    ph1_ir->dest = opstack_pop();
                 }
                 return 1;
             }
@@ -1662,25 +1856,47 @@ int read_global_assignment(char *token)
             lex_expect(T_question);
             eval_ternary_imm(val_stack[0], token);
         } else {
-            var->init_val = val_stack[0];
+            ph1_ir = add_global_ir(OP_load_constant);
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            vd->init_val = val_stack[0];
+            ph1_ir->dest = vd;
+
+            ph1_ir = add_global_ir(OP_assign);
+            ph1_ir->src0 = vd;
+            vd = require_var(parent);
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = opstack_pop();
         }
         return 1;
     }
     return 0;
 }
 
-int break_exit_ir_index[MAX_NESTING];
-int conti_jump_ir_index[MAX_NESTING];
+var_t *break_exit[MAX_NESTING];
+int break_exit_idx = 0;
+var_t *continue_pos[MAX_NESTING];
+int continue_pos_idx = 0;
+
+void perform_side_effect()
+{
+    int i;
+    for (i = 0; i < se_idx; i++) {
+        ph1_ir_t *ph1_ir = add_ph1_ir(side_effect[i].op);
+        memcpy(ph1_ir, &side_effect[i], sizeof(ph1_ir_t));
+    }
+    se_idx = 0;
+}
 
 void read_code_block(func_t *func, block_t *parent);
 
 void read_body_statement(block_t *parent)
 {
     char token[MAX_ID_LEN];
+    ph1_ir_t *ph1_ir;
     func_t *fn;
     type_t *type;
-    var_t *var;
-    ir_instr_t *ii;
+    var_t *vd, *var;
     opcode_t prefix_op = OP_generic;
 
     /* statement can be:
@@ -1694,112 +1910,155 @@ void read_body_statement(block_t *parent)
     }
 
     if (lex_accept(T_return)) {
-        if (!lex_accept(T_semicolon)) { /* can be "void" */
-            /* get expression value into return value */
-            read_expr(0, parent);
-            read_ternary_operation(0, parent);
-            lex_expect(T_semicolon);
+        /* return void */
+        if (lex_accept(T_semicolon)) {
+            add_ph1_ir(OP_return);
+            return;
         }
-        fn = parent->func;
-        ii = add_instr(OP_return);
-        ii->str_param1 = fn->return_def.var_name;
+
+        /* get expression value into return value */
+        read_expr(parent);
+        read_ternary_operation(parent);
+
+        /* apply side effect before function return */
+        perform_side_effect();
+        lex_expect(T_semicolon);
+
+        ph1_ir = add_ph1_ir(OP_return);
+        ph1_ir->src0 = opstack_pop();
         return;
     }
 
     if (lex_accept(T_if)) {
-        ir_instr_t *false_jump;
+        char label_true[32], label_false[32], label_endif[32];
+        strcpy(label_true, gen_label());
+        strcpy(label_false, gen_label());
+        strcpy(label_endif, gen_label());
 
         lex_expect(T_open_bracket);
-        read_expr(0, parent); /* get expression value into return value */
+        read_expr(parent);
         lex_expect(T_close_bracket);
 
-        false_jump = add_instr(OP_jz);
-        false_jump->param_no = 0;
+        ph1_ir = add_ph1_ir(OP_branch);
+        ph1_ir->dest = opstack_pop();
+        vd = require_var(parent);
+        strcpy(vd->var_name, label_true);
+        ph1_ir->src0 = vd;
+        vd = require_var(parent);
+        strcpy(vd->var_name, label_false);
+        ph1_ir->src1 = vd;
+
+        ph1_ir = add_ph1_ir(OP_label);
+        vd = require_var(parent);
+        strcpy(vd->var_name, label_true);
+        ph1_ir->src0 = vd;
 
         read_body_statement(parent);
 
         /* if we have an "else" block, jump to finish */
         if (lex_accept(T_else)) {
             /* jump true branch to finish */
-            ir_instr_t *true_jump = add_instr(OP_jump);
-
-            /* we will emit false branch, link false jump here */
-            ii = add_instr(OP_label);
-            false_jump->int_param1 = ii->ir_index;
+            ph1_ir = add_ph1_ir(OP_jump);
+            vd = require_var(parent);
+            strcpy(vd->var_name, label_endif);
+            ph1_ir->dest = vd;
 
             /* false branch */
+            ph1_ir = add_ph1_ir(OP_label);
+            vd = require_var(parent);
+            strcpy(vd->var_name, label_false);
+            ph1_ir->src0 = vd;
+
             read_body_statement(parent);
 
-            /* this is finish, link true jump */
-            ii = add_instr(OP_label);
-            true_jump->int_param1 = ii->ir_index;
+            ph1_ir = add_ph1_ir(OP_label);
+            vd = require_var(parent);
+            strcpy(vd->var_name, label_endif);
+            ph1_ir->src0 = vd;
         } else {
             /* this is done, and link false jump */
-            ii = add_instr(OP_label);
-            false_jump->int_param1 = ii->ir_index;
+            ph1_ir = add_ph1_ir(OP_label);
+            vd = require_var(parent);
+            strcpy(vd->var_name, label_false);
+            ph1_ir->src0 = vd;
         }
         return;
     }
 
     if (lex_accept(T_while)) {
-        ir_instr_t *false_jump;
-        ir_instr_t *start_jump =
-            add_instr(OP_jump); /* jump to while condition */
-        ir_instr_t *exit_label = add_instr(OP_label);
-        ir_instr_t *exit_jump = add_instr(OP_jump);
-        ir_instr_t *start_label = add_instr(OP_label); /* start to return to */
+        var_t *var_continue, *var_break;
+        char label_start[32], label_body[32], label_end[32];
+        strcpy(label_start, gen_label());
+        strcpy(label_body, gen_label());
+        strcpy(label_end, gen_label());
+
+        ph1_ir = add_ph1_ir(OP_label);
+        var_continue = require_var(parent);
+        strcpy(var_continue->var_name, label_start);
+        ph1_ir->src0 = var_continue;
+
+        continue_pos[continue_pos_idx++] = var_continue;
+        var_break = require_var(parent);
+        strcpy(var_break->var_name, label_end);
+        break_exit[break_exit_idx++] = var_break;
+
         lex_expect(T_open_bracket);
-        read_expr(0, parent); /* get expression value into return value */
+        read_expr(parent);
         lex_expect(T_close_bracket);
 
-        false_jump = add_instr(OP_jz);
-        false_jump->param_no = 0;
+        ph1_ir = add_ph1_ir(OP_branch);
+        ph1_ir->dest = opstack_pop();
+        vd = require_var(parent);
+        strcpy(vd->var_name, label_body);
+        ph1_ir->src0 = vd;
+        vd = require_var(parent);
+        strcpy(vd->var_name, label_end);
+        ph1_ir->src1 = vd;
 
-        start_jump->int_param1 = start_label->ir_index;
+        ph1_ir = add_ph1_ir(OP_label);
+        vd = require_var(parent);
+        strcpy(vd->var_name, label_body);
+        ph1_ir->src0 = vd;
+
+        read_body_statement(parent);
+
+        continue_pos_idx--;
+        break_exit_idx--;
 
         /* create exit jump for breaks */
-        break_exit_ir_index[break_level++] = exit_label->ir_index;
-        conti_jump_ir_index[continue_level++] = start_label->ir_index;
-        read_body_statement(parent);
-        break_level--;
-        continue_level--;
+        ph1_ir = add_ph1_ir(OP_jump);
+        vd = require_var(parent);
+        strcpy(vd->var_name, label_start);
+        ph1_ir->dest = vd;
 
-        /* unconditional jump back to expression */
-        ii = add_instr(OP_jump);
-        ii->int_param1 = start_label->ir_index;
+        ph1_ir = add_ph1_ir(OP_label);
+        ph1_ir->src0 = var_break;
 
-        /* exit label */
-        ii = add_instr(OP_label);
-        false_jump->int_param1 = ii->ir_index;
-        exit_jump->int_param1 = ii->ir_index;
+        /* workaround to keep variables alive */
+        var_continue->init_val = ph1_ir_idx - 1;
         return;
     }
 
     if (lex_accept(T_switch)) {
-        int case_values[MAX_CASES];
-        int case_ir_index[MAX_CASES];
-        int case_index = 0;
-        int default_ir_index = 0;
-        int i;
-        ir_instr_t *jump_to_check;
-        ir_instr_t *switch_exit;
+        var_t *var_break;
+        int is_default = 0;
+        char true_label[32], false_label[32];
+        strcpy(true_label, gen_label());
+        strcpy(false_label, gen_label());
 
         lex_expect(T_open_bracket);
-        read_expr(1, parent);
+        read_expr(parent);
         lex_expect(T_close_bracket);
 
-        jump_to_check = add_instr(OP_jump);
-
         /* create exit jump for breaks */
-        switch_exit = add_instr(OP_jump);
-        break_exit_ir_index[break_level++] = switch_exit->ir_index;
+        var_break = require_var(parent);
+        break_exit[break_exit_idx++] = var_break;
 
         lex_expect(T_open_curly);
         while (lex_peek(T_default, NULL) || lex_peek(T_case, NULL)) {
-            if (lex_accept(T_default)) {
-                ii = add_instr(OP_label);
-                default_ir_index = ii->ir_index;
-            } else {
+            if (lex_accept(T_default))
+                is_default = 1;
+            else {
                 int case_val;
 
                 lex_accept(T_case);
@@ -1811,75 +2070,86 @@ void read_body_statement(block_t *parent)
                     case_val = cd->value;
                     lex_expect(T_identifier); /* already read it */
                 }
-                ii = add_instr(OP_label);
-                case_values[case_index] = case_val;
-                case_ir_index[case_index++] = ii->ir_index;
+
+                ph1_ir = add_ph1_ir(OP_load_constant);
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                vd->init_val = case_val;
+                ph1_ir->dest = vd;
+                opstack_push(vd);
+
+                ph1_ir = add_ph1_ir(OP_eq);
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->src0 = opstack_pop();
+                ph1_ir->src1 = operand_stack[operand_stack_idx - 1];
+                vd = require_var(parent);
+                strcpy(vd->var_name, gen_name());
+                ph1_ir->dest = vd;
+
+                ph1_ir = add_ph1_ir(OP_branch);
+                ph1_ir->dest = vd;
+                vd = require_var(parent);
+                strcpy(vd->var_name, true_label);
+                ph1_ir->src0 = vd;
+                vd = require_var(parent);
+                strcpy(vd->var_name, false_label);
+                ph1_ir->src1 = vd;
             }
             lex_expect(T_colon);
 
             /* body is optional, can be another case */
-            while (!lex_peek(T_case, NULL) && !lex_peek(T_close_curly, NULL) &&
-                   !lex_peek(T_default, NULL)) {
-                read_body_statement(parent);
-                /* should end with a break which will generate jump out */
+            if (!is_default && !lex_peek(T_case, NULL) &&
+                !lex_peek(T_close_curly, NULL) && !lex_peek(T_default, NULL)) {
+                ph1_ir = add_ph1_ir(OP_label);
+                vd = require_var(parent);
+                strcpy(vd->var_name, true_label);
+                ph1_ir->src0 = vd;
+
+                /* only create new true label at the first line of case body */
+                strcpy(true_label, gen_label());
             }
+
+            while (!lex_peek(T_case, NULL) && !lex_peek(T_close_curly, NULL) &&
+                   !lex_peek(T_default, NULL))
+                read_body_statement(parent);
+
+            ph1_ir = add_ph1_ir(OP_label);
+            vd = require_var(parent);
+            strcpy(vd->var_name, false_label);
+            ph1_ir->src0 = vd;
+
+            /* only create new false label at the last line of case body */
+            strcpy(false_label, gen_label());
         }
+
+        /* remove the expression in switch() */
+        opstack_pop();
         lex_expect(T_close_curly);
 
-        ii = add_instr(OP_label);
-        jump_to_check->int_param1 = ii->ir_index;
-
-        /* perform checks against ?1 */
-        for (i = 0; i < case_index; i++) {
-            ii = add_instr(OP_load_constant);
-            ii->param_no = 0;
-            ii->int_param1 = case_values[i];
-            ii = add_instr(OP_eq);
-            ii->param_no = 0;
-            ii->int_param1 = 1;
-            ii = add_instr(OP_jnz);
-            ii->param_no = 0;
-            ii->int_param1 = case_ir_index[i];
-        }
-        /* jump to default */
-        if (default_ir_index) {
-            ii = add_instr(OP_jump);
-            ii->int_param1 = default_ir_index;
-        }
-
-        break_level--;
-
-        /* exit where breaks should exit to */
-        ii = add_instr(OP_label);
-        switch_exit->int_param1 = ii->ir_index;
+        strcpy(var_break->var_name, vd->var_name);
+        break_exit_idx--;
         return;
     }
 
     if (lex_accept(T_break)) {
-        ii = add_instr(OP_jump);
-        ii->int_param1 = break_exit_ir_index[break_level - 1];
+        ph1_ir = add_ph1_ir(OP_jump);
+        ph1_ir->dest = break_exit[break_exit_idx - 1];
     }
 
     if (lex_accept(T_continue)) {
-        ii = add_instr(OP_jump);
-        ii->int_param1 = conti_jump_ir_index[continue_level - 1];
+        ph1_ir = add_ph1_ir(OP_jump);
+        ph1_ir->dest = continue_pos[continue_pos_idx - 1];
     }
 
     if (lex_accept(T_for)) {
-        ir_instr_t *start_jump = add_instr(OP_jump);
-        ir_instr_t *exit_label = add_instr(OP_label);
-        ir_instr_t *exit_jump = add_instr(OP_jump);
-        ir_instr_t *start_label = add_instr(OP_label);
-        ir_instr_t *condition_start;
-        ir_instr_t *condition_jump_out;
-        ir_instr_t *condition_jump_in;
-        ir_instr_t *increment;
-        ir_instr_t *increment_jump;
-        ir_instr_t *body_start;
-        ir_instr_t *body_jump;
-        ir_instr_t *end;
+        var_t *var_condition, *var_break, *var_inc;
+        char cond[32], body[32], inc[32], end[32];
+        strcpy(cond, gen_label());
+        strcpy(body, gen_label());
+        strcpy(inc, gen_label());
+        strcpy(end, gen_label());
 
-        start_jump->int_param1 = start_label->ir_index;
         lex_expect(T_open_bracket);
 
         /* setup - execute once */
@@ -1890,24 +2160,45 @@ void read_body_statement(block_t *parent)
         }
 
         /* condition - check before the loop */
-        condition_start = add_instr(OP_label);
+        ph1_ir = add_ph1_ir(OP_label);
+        var_condition = require_var(parent);
+        strcpy(var_condition->var_name, cond);
+        ph1_ir->src0 = var_condition;
         if (!lex_accept(T_semicolon)) {
-            read_expr(0, parent);
+            read_expr(parent);
             lex_expect(T_semicolon);
         } else {
             /* always true */
-            ir_instr_t *itrue = add_instr(OP_load_constant);
-            itrue->param_no = 0;
-            itrue->int_param1 = 1;
+            ph1_ir = add_ph1_ir(OP_load_constant);
+            vd = require_var(parent);
+            vd->init_val = 1;
+            strcpy(vd->var_name, gen_name());
+            ph1_ir->dest = vd;
+            opstack_push(vd);
         }
 
-        condition_jump_out = add_instr(OP_jz); /* jump out if zero */
-        condition_jump_out->param_no = 0;
-        condition_jump_in = add_instr(OP_jump); /* else jump to body */
-        condition_jump_in->param_no = 0;
+        ph1_ir = add_ph1_ir(OP_branch);
+        ph1_ir->dest = opstack_pop();
+        vd = require_var(parent);
+        strcpy(vd->var_name, body);
+        ph1_ir->src0 = vd;
+        vd = require_var(parent);
+        strcpy(vd->var_name, end);
+        ph1_ir->src1 = vd;
+
+        var_break = require_var(parent);
+        strcpy(var_break->var_name, end);
+
+        break_exit[break_exit_idx++] = var_break;
 
         /* increment after each loop */
-        increment = add_instr(OP_label);
+        ph1_ir = add_ph1_ir(OP_label);
+        var_inc = require_var(parent);
+        strcpy(var_inc->var_name, inc);
+        ph1_ir->src0 = var_inc;
+
+        continue_pos[continue_pos_idx++] = var_inc;
+
         if (!lex_accept(T_close_bracket)) {
             if (lex_accept(T_increment))
                 prefix_op = OP_add;
@@ -1919,59 +2210,82 @@ void read_body_statement(block_t *parent)
         }
 
         /* jump back to condition */
-        increment_jump = add_instr(OP_jump);
-        increment_jump->int_param1 = condition_start->ir_index;
+        ph1_ir = add_ph1_ir(OP_jump);
+        vd = require_var(parent);
+        strcpy(vd->var_name, cond);
+        ph1_ir->dest = vd;
 
         /* loop body */
-        body_start = add_instr(OP_label);
-        condition_jump_in->int_param1 = body_start->ir_index;
-        break_exit_ir_index[break_level++] = exit_label->ir_index;
-        conti_jump_ir_index[continue_level++] = increment->ir_index;
+        ph1_ir = add_ph1_ir(OP_label);
+        vd = require_var(parent);
+        strcpy(vd->var_name, body);
+        ph1_ir->src0 = vd;
         read_body_statement(parent);
-        break_level--;
-        continue_level--;
 
         /* jump to increment */
-        body_jump = add_instr(OP_jump);
-        body_jump->int_param1 = increment->ir_index;
+        ph1_ir = add_ph1_ir(OP_jump);
+        vd = require_var(parent);
+        strcpy(vd->var_name, inc);
+        ph1_ir->dest = vd;
 
-        end = add_instr(OP_label);
-        condition_jump_out->int_param1 = end->ir_index;
-        exit_jump->int_param1 = end->ir_index;
+        ph1_ir = add_ph1_ir(OP_label);
+        ph1_ir->src0 = var_break;
+
+        var_condition->init_val = ph1_ir_idx - 1;
+
+        continue_pos_idx--;
+        break_exit_idx--;
         return;
     }
 
     if (lex_accept(T_do)) {
-        ir_instr_t *false_jump;
-        ir_instr_t *start_jump = add_instr(OP_jump);
-        ir_instr_t *cond_label;
-        ir_instr_t *cond_jump = add_instr(OP_jump);
-        ir_instr_t *exit_label;
-        ir_instr_t *exit_jump = add_instr(OP_jump);
-        ir_instr_t *start_label = add_instr(OP_label); /* start to return to */
+        var_t *var_start, *var_condition, *var_break;
 
-        start_jump->int_param1 = start_label->ir_index;
+        ph1_ir = add_ph1_ir(OP_label);
+        var_start = require_var(parent);
+        strcpy(var_start->var_name, gen_label());
+        ph1_ir->src0 = var_start;
 
-        break_exit_ir_index[break_level++] = exit_jump->ir_index;
-        conti_jump_ir_index[continue_level++] = cond_jump->ir_index;
+        var_condition = require_var(parent);
+        strcpy(var_condition->var_name, gen_label());
+
+        continue_pos[continue_pos_idx++] = var_condition;
+
+        var_break = require_var(parent);
+        strcpy(var_break->var_name, gen_label());
+
+        break_exit[break_exit_idx++] = var_break;
+
         read_body_statement(parent);
-        break_level--;
-        continue_level--;
 
-        cond_label = add_instr(OP_label);
-        cond_jump->int_param1 = cond_label->ir_index;
         lex_expect(T_while);
         lex_expect(T_open_bracket);
-        read_expr(0, parent); /* get expression value into return value */
+
+        ph1_ir = add_ph1_ir(OP_label);
+        vd = require_var(parent);
+        strcpy(vd->var_name, var_condition->var_name);
+        ph1_ir->src0 = vd;
+
+        read_expr(parent);
         lex_expect(T_close_bracket);
 
-        false_jump = add_instr(OP_jnz);
-        false_jump->param_no = 0;
-        false_jump->int_param1 = start_label->ir_index;
-        exit_label = add_instr(OP_label);
-        exit_jump->int_param1 = exit_label->ir_index;
+        ph1_ir = add_ph1_ir(OP_branch);
+        ph1_ir->dest = opstack_pop();
+        vd = require_var(parent);
+        strcpy(vd->var_name, var_start->var_name);
+        ph1_ir->src0 = vd;
+        vd = require_var(parent);
+        strcpy(vd->var_name, var_break->var_name);
+        ph1_ir->src1 = vd;
 
+        ph1_ir = add_ph1_ir(OP_label);
+        ph1_ir->src0 = var_break;
+
+        var_start->init_val = ph1_ir_idx - 1;
         lex_expect(T_semicolon);
+
+        continue_pos_idx--;
+        break_exit_idx--;
         return;
     }
 
@@ -1991,43 +2305,31 @@ void read_body_statement(block_t *parent)
     /* is it a variable declaration? */
     type = find_type(token);
     if (type) {
-        var = &parent->locals[parent->next_local++];
-        read_full_var_decl(var, 0);
+        var = require_var(parent);
+        read_full_var_decl(var, 0, 0);
         if (lex_accept(T_assign)) {
-            read_expr(1, parent); /* get expression value into ?1 */
-            read_ternary_operation(1, parent);
-            /* assign to our new variable */
+            read_expr(parent);
+            read_ternary_operation(parent);
 
-            /* load variable location */
-            ii = add_instr(OP_address_of);
-            ii->param_no = 0;
-            ii->str_param1 = var->var_name;
-
-            /* store value at specifc address, but need to know the type/size */
-            ii = add_instr(OP_write);
-            ii->param_no = 1;
-            ii->int_param1 = 0;
-            ii->int_param2 = get_size(var, type);
+            ph1_ir = add_ph1_ir(OP_assign);
+            ph1_ir->src0 = opstack_pop();
+            ph1_ir->dest = var;
         }
         while (lex_accept(T_comma)) {
+            var_t *nv;
+
+            /* add sequence point at T_comma */
+            perform_side_effect();
+
             /* multiple (partial) declarations */
-            var_t *nv = &parent->locals[parent->next_local++];
+            nv = require_var(parent);
             read_partial_var_decl(nv, var); /* partial */
             if (lex_accept(T_assign)) {
-                read_expr(1, parent); /* get expression value into ?1 */
-                /* assign to our new variable */
+                read_expr(parent);
 
-                /* load variable location */
-                ii = add_instr(OP_address_of);
-                ii->param_no = 0;
-                ii->str_param1 = nv->var_name;
-
-                /* store value at specific address, but need to know the
-                 * type/size */
-                ii = add_instr(OP_write);
-                ii->param_no = 1;
-                ii->int_param1 = 0;
-                ii->int_param2 = get_size(var, type);
+                ph1_ir = add_ph1_ir(OP_assign);
+                ph1_ir->src0 = opstack_pop();
+                ph1_ir->dest = nv;
             }
         }
         lex_expect(T_semicolon);
@@ -2037,13 +2339,16 @@ void read_body_statement(block_t *parent)
     /* is a function call? */
     fn = find_func(token);
     if (fn) {
-        read_func_call(fn, 0, parent);
+        lex_expect(T_identifier);
+        read_func_call(fn, parent);
+        perform_side_effect();
         lex_expect(T_semicolon);
         return;
     }
 
     /* is an assignment? */
     if (read_body_assignment(token, parent, prefix_op)) {
+        perform_side_effect();
         lex_expect(T_semicolon);
         return;
     }
@@ -2054,51 +2359,43 @@ void read_body_statement(block_t *parent)
 void read_code_block(func_t *func, block_t *parent)
 {
     block_t *blk = add_block(parent, func);
-    ir_instr_t *ii = add_instr(OP_block_start);
-    ii->int_param1 = blk->index;
+
+    add_ph1_ir(OP_block_start);
     lex_expect(T_open_curly);
 
-    while (!lex_accept(T_close_curly))
+    while (!lex_accept(T_close_curly)) {
         read_body_statement(blk);
+        perform_side_effect();
+    }
 
-    ii = add_instr(OP_block_end);
-    ii->int_param1 = blk->index;
+    add_ph1_ir(OP_block_end);
 }
 
 void read_func_body(func_t *fdef)
 {
-    ir_instr_t *ii;
-
     read_code_block(fdef, NULL);
-
-    /* only add return when we have no return type, as otherwise there should
-     * have been a return statement.
-     */
-    ii = add_instr(OP_func_exit);
-    ii->str_param1 = fdef->return_def.var_name;
-    fdef->exit_point = ii->ir_index;
 }
 
 /* if first token is type */
 void read_global_decl(block_t *block)
 {
-    var_t tmp;
+    var_t *var = require_var(block);
+    var->is_global = 1;
+
     /* new function, or variables under parent */
-    read_full_var_decl(&tmp, 0);
+    read_full_var_decl(var, 0, 0);
 
     if (lex_peek(T_open_bracket, NULL)) {
-        ir_instr_t *ii;
-
         /* function */
-        func_t *fd = add_func(tmp.var_name);
-        memcpy(&fd->return_def, &tmp, sizeof(var_t));
+        func_t *fd = add_func(var->var_name);
+        memcpy(&fd->return_def, var, sizeof(var_t));
+        block->next_local--;
 
-        fd->num_params = read_parameter_list_decl(fd->param_defs, 0);
+        read_parameter_list_decl(fd, 0);
 
         if (lex_peek(T_open_curly, NULL)) {
-            ii = add_instr(OP_func_extry);
-            ii->str_param1 = fd->return_def.var_name;
-            fd->entry_point = ii->ir_index;
+            ph1_ir_t *ph1_ir = add_ph1_ir(OP_define);
+            strcpy(ph1_ir->func_name, var->var_name);
 
             read_func_body(fd);
             return;
@@ -2108,12 +2405,11 @@ void read_global_decl(block_t *block)
         error("Syntax error in global declaration");
     }
 
+    /* NO support for global initialization */
     /* is a variable */
-    memcpy(&block->locals[block->next_local++], &tmp, sizeof(var_t));
-
     if (lex_accept(T_assign)) {
-        if (tmp.is_ptr == 0 && tmp.array_size == 0) {
-            read_global_assignment(tmp.var_name);
+        if (var->is_ptr == 0 && var->array_size == 0) {
+            read_global_assignment(var->var_name);
             lex_expect(T_semicolon);
             return;
         }
@@ -2122,8 +2418,10 @@ void read_global_decl(block_t *block)
     } else if (lex_accept(T_comma))
         /* TODO: continuation */
         error("Global continuation not supported");
-    else if (lex_accept(T_semicolon))
+    else if (lex_accept(T_semicolon)) {
+        opstack_pop();
         return;
+    }
     error("Syntax error in global declaration");
 }
 
@@ -2180,7 +2478,7 @@ void read_global_statement()
             lex_expect(T_open_curly);
             do {
                 var_t *v = &type->fields[i++];
-                read_full_var_decl(v, 0);
+                read_full_var_decl(v, 0, 1);
                 v->offset = size;
                 size += size_var(v);
                 lex_expect(T_semicolon);
@@ -2215,7 +2513,6 @@ void read_global_statement()
 void parse_internal()
 {
     /* parser initialization */
-    ir_instr_t *ii;
     type_t *type;
     func_t *fn;
 
@@ -2238,31 +2535,9 @@ void parse_internal()
     /* architecture defines */
     add_alias(ARCH_PREDEFINED, "1");
 
-    /* binary entry point: read params, call main, exit */
-    ii = add_instr(OP_label);
-    ii->str_param1 = "__start";
-    add_instr(OP_start);
-    ii = add_instr(OP_call);
-    ii->str_param1 = "main";
-    ii = add_instr(OP_label);
-    ii->str_param1 = "__exit";
-    exit_ii = add_instr(OP_exit);
-
     /* Linux syscall */
     fn = add_func("__syscall");
-    fn->num_params = 0;
-    ii = add_instr(OP_func_extry);
-    fn->entry_point = ii->ir_index;
-    ii->str_param1 = fn->return_def.var_name;
-    ii = add_instr(OP_syscall);
-    ii->str_param1 = fn->return_def.var_name;
-    ii = add_instr(OP_func_exit);
-    ii->str_param1 = fn->return_def.var_name;
-    fn->exit_point = ii->ir_index;
-
-    /* internal */
-    break_level = 0;
-    continue_level = 0;
+    fn->va_args = 1;
 
     /* lexer initialization */
     source_idx = 0;

--- a/src/globals.c
+++ b/src/globals.c
@@ -4,13 +4,24 @@ block_t *BLOCKS;
 int blocks_idx = 0;
 
 func_t *FUNCS;
-int funcs_idx = 0;
+int funcs_idx = 1;
 
 type_t *TYPES;
 int types_idx = 0;
 
-ir_instr_t *IR;
-int ir_idx = 0;
+ph1_ir_t *GLOBAL_IR;
+int global_ir_idx = 0;
+
+ph1_ir_t *PH1_IR;
+int ph1_ir_idx = 0;
+
+ph2_ir_t *PH2_IR;
+int ph2_ir_idx = 0;
+
+label_lut_t *LABEL_LUT;
+int label_lut_idx = 0;
+
+regfile_t REG[REG_CNT];
 
 alias_t *ALIASES;
 int aliases_idx = 0;
@@ -29,7 +40,7 @@ char *elf_data;
 int elf_data_idx = 0;
 char *elf_header;
 int elf_header_idx = 0;
-int elf_header_len = 0x54; /* ELF fixed: 0x34 + 1 * 0x20 */
+int elf_header_len; /* ELF fixed: 0x34 + 1 * 0x20 */
 int elf_code_start;
 char *elf_symtab;
 char *elf_strtab;
@@ -48,14 +59,48 @@ type_t *find_type(char *type_name)
     return NULL;
 }
 
-ir_instr_t *add_instr(opcode_t op)
+ph1_ir_t *add_global_ir(opcode_t op)
 {
-    ir_instr_t *ii = &IR[ir_idx];
-    ii->op = op;
-    ii->op_len = 0;
-    ii->str_param1 = 0;
-    ii->ir_index = ir_idx++;
-    return ii;
+    ph1_ir_t *ir = &GLOBAL_IR[global_ir_idx++];
+    ir->op = op;
+    return ir;
+}
+
+ph1_ir_t *add_ph1_ir(opcode_t op)
+{
+    ph1_ir_t *ph1_ir = &PH1_IR[ph1_ir_idx++];
+    ph1_ir->op = op;
+    return ph1_ir;
+}
+
+ph2_ir_t *add_ph2_ir(opcode_t op)
+{
+    ph2_ir_t *ph2_ir = &PH2_IR[ph2_ir_idx++];
+    ph2_ir->op = op;
+    return ph2_ir;
+}
+
+void set_var_liveout(var_t *var, int end)
+{
+    if (var->eol >= end)
+        return;
+    var->eol = end;
+}
+
+void add_label(char *name, int offset)
+{
+    label_lut_t *lut = &LABEL_LUT[label_lut_idx++];
+    strcpy(lut->name, name);
+    lut->offset = offset;
+}
+
+int find_label_offset(char name[])
+{
+    int i;
+    for (i = 0; i < label_lut_idx; i++)
+        if (!strcmp(LABEL_LUT[i].name, name))
+            return LABEL_LUT[i].offset;
+    return -1;
 }
 
 block_t *add_block(block_t *parent, func_t *func)
@@ -95,6 +140,7 @@ func_t *add_func(char *name)
             return &FUNCS[i];
 
     fn = &FUNCS[funcs_idx++];
+    fn->stack_size = 4;
     strcpy(fn->return_def.var_name, name);
     return fn;
 }
@@ -207,12 +253,16 @@ int size_var(var_t *var)
  */
 void global_init()
 {
+    elf_header_len = 0x54;
     elf_code_start = ELF_START + elf_header_len;
 
     BLOCKS = malloc(MAX_BLOCKS * sizeof(block_t));
     FUNCS = malloc(MAX_FUNCS * sizeof(func_t));
     TYPES = malloc(MAX_TYPES * sizeof(type_t));
-    IR = malloc(MAX_IR_INSTR * sizeof(ir_instr_t));
+    GLOBAL_IR = malloc(MAX_GLOBAL_IR * sizeof(ph1_ir_t));
+    PH1_IR = malloc(MAX_IR_INSTR * sizeof(ph1_ir_t));
+    PH2_IR = malloc(MAX_IR_INSTR * sizeof(ph2_ir_t));
+    LABEL_LUT = malloc(MAX_LABEL * sizeof(label_lut_t));
     SOURCE = malloc(MAX_SOURCE);
     ALIASES = malloc(MAX_ALIASES * sizeof(alias_t));
     CONSTANTS = malloc(MAX_CONSTANTS * sizeof(constant_t));
@@ -223,12 +273,257 @@ void global_init()
     elf_symtab = malloc(MAX_SYMTAB);
     elf_strtab = malloc(MAX_STRTAB);
     elf_section = malloc(MAX_SECTION);
+
+    FUNCS[0].stack_size = 4;
 }
 
 void error(char *msg)
 {
     /* TODO: figure out the corresponding C source and report line number */
-    printf("Error %s at source location %d, IR index %d\n", msg, source_idx,
-           ir_idx);
+    printf("Error %s at source location %d\n", msg, source_idx);
     abort();
+}
+
+void print_indent(int indent)
+{
+    int i;
+    for (i = 0; i < indent; i++)
+        printf("\t");
+}
+
+void dump_ph1_ir()
+{
+    int indent = 0;
+    ph1_ir_t *ph1_ir;
+    func_t *fn;
+    int i, j, k;
+
+    if (dump_ir == 0)
+        return;
+
+    for (i = 0; i < ph1_ir_idx; i++) {
+        ph1_ir = &PH1_IR[i];
+
+        switch (ph1_ir->op) {
+        case OP_define:
+            fn = find_func(ph1_ir->func_name);
+            printf("def %s", fn->return_def.type_name);
+
+            for (j = 0; j < fn->return_def.is_ptr; j++)
+                printf("*");
+            printf(" @%s(", ph1_ir->func_name);
+
+            for (j = 0; j < fn->num_params; j++) {
+                if (j != 0)
+                    printf(", ");
+                printf("%s", fn->param_defs[j].type_name);
+
+                for (k = 0; k < fn->param_defs[j].is_ptr; k++)
+                    printf("*");
+                printf(" %%%s", fn->param_defs[j].var_name);
+            }
+            printf(")");
+            break;
+        case OP_block_start:
+            print_indent(indent);
+            printf("{");
+            indent++;
+            break;
+        case OP_block_end:
+            indent--;
+            print_indent(indent);
+            printf("}");
+            break;
+        case OP_allocat:
+            print_indent(indent);
+            printf("allocat %s", ph1_ir->src0->type_name);
+            for (j = 0; j < ph1_ir->src0->is_ptr; j++)
+                printf("*");
+            printf(" %%%s", ph1_ir->src0->var_name);
+
+            if (ph1_ir->src0->array_size > 0)
+                printf("[%d]", ph1_ir->src0->array_size);
+            break;
+        case OP_label:
+            print_indent(0);
+            printf("%s", ph1_ir->src0->var_name);
+            break;
+        case OP_branch:
+            print_indent(indent);
+            printf("br %%%s, %s, %s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_jump:
+            print_indent(indent);
+            printf("j %s", ph1_ir->dest->var_name);
+            break;
+        case OP_load_constant:
+            print_indent(indent);
+            printf("const %%%s, $%d", ph1_ir->dest->var_name,
+                   ph1_ir->dest->init_val);
+            break;
+        case OP_assign:
+            print_indent(indent);
+            printf("%%%s = %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_push:
+            print_indent(indent);
+            printf("push %%%s", ph1_ir->src0->var_name);
+            break;
+        case OP_call:
+            print_indent(indent);
+            printf("call @%s, %d", ph1_ir->func_name, ph1_ir->param_num);
+            break;
+        case OP_func_ret:
+            print_indent(indent);
+            printf("retval %%%s", ph1_ir->dest->var_name);
+            break;
+        case OP_return:
+            print_indent(indent);
+            if (ph1_ir->src0)
+                printf("ret %%%s", ph1_ir->src0->var_name);
+            else
+                printf("ret");
+            break;
+        case OP_load_data_address:
+            print_indent(indent);
+            /* offset from .data section */
+            printf("%%%s = .data (%d)", ph1_ir->dest->var_name,
+                   ph1_ir->dest->init_val);
+            break;
+        case OP_address_of:
+            print_indent(indent);
+            printf("%%%s = &(%%%s)", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_read:
+            print_indent(indent);
+            printf("%%%s = (%%%s), %d", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->size);
+            break;
+        case OP_write:
+            print_indent(indent);
+            if (ph1_ir->src0->is_func)
+                printf("(%%%s) = @%s", ph1_ir->dest->var_name,
+                       ph1_ir->src0->var_name);
+            else
+                printf("(%%%s) = %%%s, %d", ph1_ir->dest->var_name,
+                       ph1_ir->src0->var_name, ph1_ir->size);
+            break;
+        case OP_indirect:
+            print_indent(indent);
+            printf("indirect call @(%%%s)", ph1_ir->src0->var_name);
+            break;
+        case OP_negate:
+            print_indent(indent);
+            printf("neg %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_add:
+            print_indent(indent);
+            printf("%%%s = add %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_sub:
+            print_indent(indent);
+            printf("%%%s = sub %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_mul:
+            print_indent(indent);
+            printf("%%%s = mul %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_div:
+            print_indent(indent);
+            printf("%%%s = div %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_mod:
+            print_indent(indent);
+            printf("%%%s = mod %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_eq:
+            print_indent(indent);
+            printf("%%%s = eq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_neq:
+            print_indent(indent);
+            printf("%%%s = neq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_gt:
+            print_indent(indent);
+            printf("%%%s = gt %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_lt:
+            print_indent(indent);
+            printf("%%%s = lt %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_geq:
+            print_indent(indent);
+            printf("%%%s = geq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_leq:
+            print_indent(indent);
+            printf("%%%s = leq %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_bit_and:
+            print_indent(indent);
+            printf("%%%s = and %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_bit_or:
+            print_indent(indent);
+            printf("%%%s = or %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_bit_not:
+            print_indent(indent);
+            printf("%%%s = not %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_bit_xor:
+            print_indent(indent);
+            printf("%%%s = xor %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_log_and:
+            print_indent(indent);
+            printf("%%%s = and %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_log_or:
+            print_indent(indent);
+            printf("%%%s = or %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_log_not:
+            print_indent(indent);
+            printf("%%%s = not %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name);
+            break;
+        case OP_rshift:
+            print_indent(indent);
+            printf("%%%s = rshift %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        case OP_lshift:
+            print_indent(indent);
+            printf("%%%s = lshift %%%s, %%%s", ph1_ir->dest->var_name,
+                   ph1_ir->src0->var_name, ph1_ir->src1->var_name);
+            break;
+        default:
+            break;
+        }
+        printf("\n");
+    }
+    printf("===\n");
 }

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -2,615 +2,1317 @@
 
 #include "riscv.c"
 
-/* Compute stack space needed for function's parameters */
-void size_func(func_t *fn)
-{
-    int s = 0, i;
-
-    /* parameters are turned into local variables */
-    for (i = 0; i < fn->num_params; i++) {
-        s += size_var(&fn->param_defs[i]);
-        fn->param_defs[i].offset = s; /* stack offset */
-    }
-
-    /* align to 16 bytes */
-    if ((s & 15) > 0)
-        s = (s - (s & 15)) + 16;
-    if (s > 2047)
-        error("Local stack size exceeded");
-
-    fn->params_size = s;
-}
-
-/* Return stack size required after block local variables */
-int size_block(block_t *blk)
-{
-    int size = 0, i, offset;
-
-    /* our offset starts from parent's offset */
-    if (!blk->parent)
-        offset = blk->func ? blk->func->params_size : 0;
-    else
-        offset = size_block(blk->parent);
-
-    /* declared locals */
-    for (i = 0; i < blk->next_local; i++) {
-        int vs = size_var(&blk->locals[i]);
-        /* look up value off stack */
-        blk->locals[i].offset = size + offset + vs;
-        size += vs;
-    }
-
-    /* align to 16 bytes */
-    if ((size & 15) > 0)
-        size = (size - (size & 15)) + 16;
-    if (size > 2047)
-        error("Local stack size exceeded");
-
-    /* save in block for stack allocation */
-    blk->locals_size = size;
-    return size + offset;
-}
-
-/* Compute stack necessary sizes for all functions */
-void size_funcs(int data_start)
-{
-    block_t *blk;
-    int i;
-
-    /* size functions */
-    for (i = 0; i < funcs_idx; i++)
-        size_func(&FUNCS[i]);
-
-    /* size blocks excl. global block */
-    for (i = 1; i < blocks_idx; i++)
-        size_block(&BLOCKS[i]);
-
-    /* allocate data for globals, in block 0 */
-    blk = &BLOCKS[0];
-    for (i = 0; i < blk->next_local; i++) {
-        blk->locals[i].offset = elf_data_idx; /* set offset in data section */
-        elf_add_symbol(blk->locals[i].var_name, strlen(blk->locals[i].var_name),
-                       data_start + elf_data_idx);
-        /* TODO: add .bss section */
-        if (!strcmp(blk->locals[i].type_name, "int") &&
-            blk->locals[i].init_val != 0)
-            elf_write_data_int(blk->locals[i].init_val);
-        else
-            elf_data_idx += size_var(&blk->locals[i]);
-    }
-}
-
-/* Return expected binary length of an IR instruction in bytes */
-int get_code_length(ir_instr_t *ii)
-{
-    opcode_t op = ii->op;
-
-    switch (op) {
-    case OP_func_extry: {
-        func_t *fn = find_func(ii->str_param1);
-        return 16 + (fn->num_params << 2);
-    }
-    case OP_call:
-    case OP_indirect:
-        return ii->param_no ? 8 : 4;
-    case OP_load_constant:
-        return (ii->int_param1 > -2048 && ii->int_param1 < 2047) ? 4 : 8;
-    case OP_block_start:
-    case OP_block_end: {
-        block_t *blk = &BLOCKS[ii->int_param1];
-        return (blk->next_local > 0) ? 4 : 0;
-    }
-    case OP_syscall:
-        return 20;
-    case OP_eq:
-    case OP_neq:
-    case OP_lt:
-    case OP_leq:
-    case OP_gt:
-    case OP_geq:
-    case OP_func_exit:
-        return 16;
-    case OP_exit:
-        return 12;
-    case OP_load_data_address:
-    case OP_jz:
-    case OP_jnz:
-    case OP_push:
-    case OP_pop:
-    case OP_address_of:
-    case OP_start:
-        return 8;
-    case OP_jump:
-    case OP_return:
-    case OP_add:
-    case OP_sub:
-    case OP_mul:
-    case OP_div:
-    case OP_mod:
-    case OP_read:
-    case OP_write:
-    case OP_log_or:
-    case OP_log_and:
-    case OP_log_not:
-    case OP_bit_or:
-    case OP_bit_and:
-    case OP_bit_xor:
-    case OP_bit_not:
-    case OP_negate:
-    case OP_lshift:
-    case OP_rshift:
-        return 4;
-    case OP_label:
-        return 0;
-    default:
-        error("Unsupported IR opcode");
-    }
-    return 0;
-}
-
 void emit(int code)
 {
     elf_write_code_int(code);
 }
 
-/* Compute total binary code length based on IR opcode */
-int total_code_length()
+void expire_regs(int i)
 {
-    int code_len = 0, i;
-    for (i = 0; i < ir_idx; i++) {
-        IR[i].code_offset = code_len;
-        IR[i].op_len = get_code_length(&IR[i]);
-        code_len += IR[i].op_len;
+    int t;
+    for (t = 0; t < REG_CNT; t++) {
+        if (REG[t].var == NULL)
+            continue;
+        if (REG[t].var->eol < i) {
+            REG[t].var = NULL;
+            REG[t].polluted = 0;
+        }
     }
-    return code_len;
 }
+
+int find_in_regs(var_t *var)
+{
+    int i;
+    for (i = 0; i < REG_CNT; i++)
+        if (REG[i].var == var)
+            return i;
+    return -1;
+}
+
+int try_avl_reg()
+{
+    int i;
+    for (i = 0; i < REG_CNT; i++)
+        if (REG[i].var == NULL)
+            return i;
+    return -1;
+}
+
+/* return the available index of register, spill out the value in
+ * it if needed */
+int get_src_reg(func_t *fn, var_t *var, int reserved)
+{
+    ph2_ir_t *ph2_ir;
+    int reg_idx, i, ofs, t = 0;
+
+    reg_idx = find_in_regs(var);
+    if (reg_idx > -1)
+        return reg_idx;
+
+    reg_idx = try_avl_reg();
+    if (reg_idx > -1) {
+        REG[reg_idx].var = var;
+        REG[reg_idx].polluted = 0;
+
+        if (var->is_global == 1)
+            ph2_ir = add_ph2_ir(OP_global_load);
+        else
+            ph2_ir = add_ph2_ir(OP_load);
+        ph2_ir->dest = reg_idx;
+        ph2_ir->src0 = var->offset;
+        return reg_idx;
+    }
+
+    for (i = 0; i < REG_CNT; i++) {
+        if (reserved == i)
+            continue;
+        if (REG[i].var->eol > t) {
+            t = REG[i].var->eol;
+            reg_idx = i;
+        }
+    }
+
+    /* skip this: it should spill itself if it has the longest lifetime */
+    if (0 && var->eol > REG[reg_idx].var->eol) {
+        ;
+    } else {
+        ofs = REG[reg_idx].var->offset;
+        if (ofs == 0) {
+            if (REG[reg_idx].var->is_global == 1) {
+                ofs = FUNCS[0].stack_size;
+                REG[reg_idx].var->offset = ofs;
+                FUNCS[0].stack_size += 4;
+            } else {
+                ofs = fn->stack_size;
+                REG[reg_idx].var->offset = ofs;
+                fn->stack_size += 4;
+            }
+        }
+        if (REG[reg_idx].polluted) {
+            if (REG[reg_idx].var->is_global == 1)
+                ph2_ir = add_ph2_ir(OP_global_store);
+            else
+                ph2_ir = add_ph2_ir(OP_store);
+            ph2_ir->src0 = reg_idx;
+            ph2_ir->src1 = ofs;
+        }
+
+        REG[reg_idx].var = var;
+
+        if (var->is_global == 1)
+            ph2_ir = add_ph2_ir(OP_global_load);
+        else
+            ph2_ir = add_ph2_ir(OP_load);
+        ph2_ir->dest = reg_idx;
+        ph2_ir->src0 = var->offset;
+        REG[reg_idx].polluted = 0;
+        return reg_idx;
+    }
+}
+
+/* `hold_src1` is used for `OP_log_and` */
+int get_dest_reg(func_t *fn,
+                 var_t *var,
+                 int pc,
+                 int src0,
+                 int src1,
+                 int hold_src1)
+{
+    ph2_ir_t *ph2_ir;
+    int reg_idx, i, ofs, t = 0;
+
+    reg_idx = find_in_regs(var);
+    if (reg_idx > -1) {
+        REG[reg_idx].polluted = 1;
+        return reg_idx;
+    }
+
+    reg_idx = try_avl_reg();
+    if (reg_idx > -1) {
+        REG[reg_idx].var = var;
+        REG[reg_idx].polluted = 1;
+        return reg_idx;
+    }
+
+    if (src0 > -1)
+        if (REG[src0].var->eol == pc) {
+            REG[src0].var = var;
+            REG[src0].polluted = 1;
+            return src0;
+        }
+    if (!hold_src1 && src1 > -1)
+        if (REG[src1].var->eol == pc) {
+            REG[src1].var = var;
+            REG[src1].polluted = 1;
+            return src1;
+        }
+
+    for (i = 0; i < REG_CNT; i++) {
+        if (hold_src1 && src1 == i)
+            continue;
+        if (REG[i].var->eol > t) {
+            t = REG[i].var->eol;
+            reg_idx = i;
+        }
+    }
+
+    if (0 && var->eol > REG[reg_idx].var->eol) {
+        ;
+    } else {
+        ofs = REG[reg_idx].var->offset;
+        if (ofs == 0) {
+            if (REG[reg_idx].var->is_global == 1) {
+                ofs = FUNCS[0].stack_size;
+                REG[reg_idx].var->offset = ofs;
+                FUNCS[0].stack_size += 4;
+            } else {
+                ofs = fn->stack_size;
+                REG[reg_idx].var->offset = ofs;
+                fn->stack_size += 4;
+            }
+        }
+        if (REG[reg_idx].polluted) {
+            if (REG[reg_idx].var->is_global == 1)
+                ph2_ir = add_ph2_ir(OP_global_store);
+            else
+                ph2_ir = add_ph2_ir(OP_store);
+            ph2_ir->src0 = reg_idx;
+            ph2_ir->src1 = ofs;
+        }
+
+        REG[reg_idx].var = var;
+        REG[reg_idx].polluted = 1;
+        return reg_idx;
+    }
+}
+
+/* If it's the end of a block, spill the global vars only */
+void spill_used_regs(func_t *fn, int pc, int global_only)
+{
+    int i, ofs;
+    ph2_ir_t *ph2_ir;
+    for (i = 0; i < REG_CNT; i++) {
+        if (REG[i].var == NULL)
+            continue;
+
+        /* if the var is going to expire after this instruction,
+         * don't store it */
+        if (REG[i].var->eol == pc)
+            continue;
+
+        if (REG[i].polluted == 0) {
+            REG[i].var = NULL;
+            continue;
+        }
+
+        if (REG[i].var->is_global == 1)
+            ph2_ir = add_ph2_ir(OP_global_store);
+        else if (!global_only)
+            ph2_ir = add_ph2_ir(OP_store);
+        else
+            continue;
+
+        ph2_ir->src0 = i;
+        ofs = REG[i].var->offset;
+        if (ofs == 0) {
+            if (REG[i].var->is_global == 1) {
+                ofs = FUNCS[0].stack_size;
+                REG[i].var->offset = ofs;
+                FUNCS[0].stack_size += 4;
+            } else {
+                ofs = fn->stack_size;
+                REG[i].var->offset = ofs;
+                fn->stack_size += 4;
+            }
+        }
+        ph2_ir->src1 = ofs;
+
+        REG[i].var = NULL;
+        REG[i].polluted = 0;
+    }
+}
+
+void dump_ph2_ir();
 
 void code_generate()
 {
-    int stack_size = 0, i;
-    block_t *blk = NULL;
-    int _c_block_level = 0;
+    ph1_ir_t *ph1_ir;
+    ph2_ir_t *ph2_ir;
+    func_t *fn;
+    int i, j, ofs;
+    int reg_idx, reg_idx_src0, reg_idx_src1;
+    int elf_data_start;
 
-    int code_start = elf_code_start; /* ELF headers size */
-    int data_start = total_code_length();
-    size_funcs(code_start + data_start);
-    for (i = 0; i < ir_idx; i++) {
-        var_t *var;
-        func_t *fn;
+    int argument_idx = 0;
+    int block_lv = 0;
 
-        ir_instr_t *ii = &IR[i];
-        opcode_t op = ii->op;
-        int pc = elf_code_idx;
-        int ofs, val;
-        int dest_reg = ii->param_no + 10; /* RISC-V specific */
-        int OP_reg = ii->int_param1 + 10; /* RISC-V specific */
 
-        if (dump_ir == 1) {
-            int j;
-            printf("%#010x     ", code_start + pc);
-            /* Use 4 space indentation */
-            for (j = 0; j < _c_block_level; j++)
-                printf("    ");
-        }
+    int loop_end_idx = 0;
 
-        switch (op) {
-        case OP_load_data_address:
-            /* lookup address of a constant in data section */
-            ofs = data_start + ii->int_param1;
-            ofs -= pc;
-            emit(__auipc(dest_reg, rv_hi(ofs)));
-            emit(__addi(dest_reg, dest_reg, rv_lo(ofs)));
-            if (dump_ir == 1)
-                printf("    x%d := &data[%d]", dest_reg, ii->int_param1);
-            break;
-        case OP_load_constant:
-            /* load numeric constant */
-            val = ii->int_param1;
-            if (val > -2048 && val < 2047) {
-                emit(__addi(dest_reg, __zero, rv_lo(val)));
-            } else {
-                emit(__lui(dest_reg, rv_hi(val)));
-                emit(__addi(dest_reg, dest_reg, rv_lo(val)));
+    /* extend live range which is "write after read (WAR)" in loop to make sure
+     * the storage*/
+    int loop_lv[10];
+    int loop_lv_idx = 0;
+
+    dump_ph1_ir();
+
+    for (i = 0; i < global_ir_idx; i++) {
+        ph1_ir = &GLOBAL_IR[i];
+        if (ph1_ir->op == OP_allocat) {
+            set_var_liveout(ph1_ir->src0, 1 << 28);
+
+        } else if (ph1_ir->op == OP_assign) {
+            set_var_liveout(ph1_ir->src0, i);
+        } else if (ph1_ir->op != OP_load_constant)
+            error("Unsupported global operation");
+    }
+
+    for (i = 0; i < ph1_ir_idx; i++) {
+        ph1_ir = &PH1_IR[i];
+
+        switch (ph1_ir->op) {
+        case OP_allocat:
+            if (ph1_ir->src0->is_global == 1) {
+                set_var_liveout(ph1_ir->src0, 1 << 28);
+                error("Unknown global allocation in body statement");
             }
-            if (dump_ir == 1)
-                printf("    x%d := %d", dest_reg, ii->int_param1);
             break;
-        case OP_address_of:
-            /* lookup address of a variable */
-            var = find_global_var(ii->str_param1);
-            if (var) {
-                int ofs = data_start + var->offset;
-                /* need to find the variable offset in data section, from PC */
-                ofs -= pc;
-
-                emit(__auipc(dest_reg, rv_hi(ofs)));
-                emit(__addi(dest_reg, dest_reg, rv_lo(ofs)));
-            } else {
-                /* need to find the variable offset on stack, i.e. from s0 */
-                var = find_local_var(ii->str_param1, blk);
-                if (var) {
-                    int offset = -var->offset;
-                    emit(__addi(dest_reg, __s0, 0));
-                    emit(__addi(dest_reg, dest_reg, offset));
-                } else {
-                    /* is it function address? */
-                    fn = find_func(ii->str_param1);
-                    if (fn) {
-                        int jump_instr_index = fn->entry_point;
-                        ir_instr_t *jump_instr = &IR[jump_instr_index];
-                        /* load code offset into variable */
-                        ofs = code_start + jump_instr->code_offset;
-                        emit(__lui(dest_reg, rv_hi(ofs)));
-                        emit(__addi(dest_reg, dest_reg, rv_lo(ofs)));
-                    } else
-                        error("Undefined identifier");
-                }
-            }
-            if (dump_ir == 1)
-                printf("    x%d = &%s", dest_reg, ii->str_param1);
-            break;
-        case OP_read:
-            /* read (dereference) memory address */
-            switch (ii->int_param2) {
-            case 4:
-                emit(__lw(dest_reg, OP_reg, 0));
-                break;
-            case 1:
-                emit(__lb(dest_reg, OP_reg, 0));
-                break;
-            default:
-                error("Unsupported word size");
-            }
-            if (dump_ir == 1)
-                printf("    x%d = *x%d (%d)", dest_reg, OP_reg, ii->int_param2);
-            break;
-        case OP_write:
-            /* write at memory address */
-            switch (ii->int_param2) {
-            case 4:
-                emit(__sw(dest_reg, OP_reg, 0));
-                break;
-            case 1:
-                emit(__sb(dest_reg, OP_reg, 0));
-                break;
-            default:
-                error("Unsupported word size");
-            }
-            if (dump_ir == 1)
-                printf("    *x%d = x%d (%d)", OP_reg, dest_reg, ii->int_param2);
-            break;
-        case OP_jump: {
-            /* unconditional jump to an IL-index */
-            int jump_instr_index = ii->int_param1;
-            ir_instr_t *jump_instr = &IR[jump_instr_index];
-            int jump_location = jump_instr->code_offset;
-            ofs = jump_location - pc;
-
-            emit(__jal(__zero, ofs));
-            if (dump_ir == 1)
-                printf("    goto %d", ii->int_param1);
-        } break;
-        case OP_return: {
-            /* jump to function exit */
-            func_t *fd = find_func(ii->str_param1);
-            int jump_instr_index = fd->exit_point;
-            ir_instr_t *jump_instr = &IR[jump_instr_index];
-            int jump_location = jump_instr->code_offset;
-            ofs = jump_location - pc;
-
-            emit(__jal(__zero, ofs));
-            if (dump_ir == 1)
-                printf("    return (from %s)", ii->str_param1);
-        } break;
-        case OP_call: {
-            /* function call */
-            int jump_instr_index;
-            ir_instr_t *jump_instr;
-            int jump_location;
-
-            /* need to find offset */
-            fn = find_func(ii->str_param1);
-            jump_instr_index = fn->entry_point;
-            jump_instr = &IR[jump_instr_index];
-            jump_location = jump_instr->code_offset;
-            ofs = jump_location - pc;
-
-            emit(__jal(__ra, ofs));
-            if (dest_reg != __a0)
-                emit(__add(dest_reg, __zero, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d := %s() @ %d", dest_reg, ii->str_param1,
-                       fn->entry_point);
-        } break;
-        case OP_indirect:
-            /* indirect call with function pointer.
-             * address in OP_reg, result in dest_reg
-             */
-            emit(__jalr(__ra, OP_reg, 0));
-            if (dest_reg != __a0)
-                emit(__addi(dest_reg, __a0, 0));
-            if (dump_ir == 1)
-                printf("    x%d := x%d()", dest_reg, OP_reg);
-            break;
-        case OP_push:
-            /* 16 aligned although we only need 4 */
-            emit(__addi(__sp, __sp, -16));
-            emit(__sw(dest_reg, __sp, 0));
-            if (dump_ir == 1)
-                printf("    push x%d", dest_reg);
-            break;
-        case OP_pop:
-            emit(__lw(dest_reg, __sp, 0));
-            /* 16 aligned although we only need 4 */
-            emit(__addi(__sp, __sp, 16));
-            if (dump_ir == 1)
-                printf("    pop x%d", dest_reg);
-            break;
-        case OP_func_exit:
-            /* restore previous frame */
-            emit(__addi(__sp, __s0, 16));
-            emit(__lw(__ra, __sp, -8));
-            emit(__lw(__s0, __sp, -4));
-            emit(__jalr(__zero, __ra, 0));
-            fn = NULL;
-            if (dump_ir == 1)
-                printf("    exit %s", ii->str_param1);
-            break;
-        case OP_add:
-            emit(__add(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d += x%d", dest_reg, OP_reg);
-            break;
-        case OP_sub:
-            emit(__sub(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d -= x%d", dest_reg, OP_reg);
-            break;
-        case OP_mul:
-            emit(__mul(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d *= x%d", dest_reg, OP_reg);
-            break;
-        case OP_div:
-            emit(__div(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d /= x%d", dest_reg, OP_reg);
-            break;
-        case OP_mod:
-            emit(__mod(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d = x%d mod x%d", dest_reg, dest_reg, OP_reg);
-            break;
-        case OP_negate:
-            emit(__sub(dest_reg, __zero, dest_reg));
-            if (dump_ir == 1)
-                printf("    -x%d", dest_reg);
+        case OP_assign:
+            set_var_liveout(ph1_ir->src0, i);
+            if (loop_end_idx != 0)
+                ph1_ir->src0->in_loop = 1;
+            if (ph1_ir->dest->in_loop != 0)
+                set_var_liveout(ph1_ir->dest, loop_end_idx);
             break;
         case OP_label:
-            if (ii->str_param1)
-                /* TODO: lazy eval */
-                if (strlen(ii->str_param1) > 0)
-                    elf_add_symbol(ii->str_param1, strlen(ii->str_param1),
-                                   code_start + pc);
-            if (dump_ir == 1)
-                printf("%4d:", i);
+            if (loop_end_idx == i) {
+                loop_end_idx = loop_lv[--loop_lv_idx];
+                break;
+            }
+            if (ph1_ir->src0->init_val != 0) {
+                loop_lv[loop_lv_idx++] = loop_end_idx;
+                loop_end_idx = ph1_ir->src0->init_val;
+            }
             break;
+        case OP_branch:
+            set_var_liveout(ph1_ir->dest, i);
+            break;
+        case OP_push:
+            set_var_liveout(ph1_ir->src0, i);
+            break;
+        case OP_return:
+            if (ph1_ir->src0)
+                set_var_liveout(ph1_ir->src0, i);
+            break;
+        case OP_address_of:
+            set_var_liveout(ph1_ir->src0, i);
+            if (loop_end_idx != 0)
+                ph1_ir->src0->in_loop = 1;
+            if (ph1_ir->dest->in_loop != 0)
+                set_var_liveout(ph1_ir->dest, loop_end_idx);
+            break;
+        case OP_read:
+            set_var_liveout(ph1_ir->src0, i);
+            if (loop_end_idx != 0)
+                ph1_ir->src0->in_loop = 1;
+            if (ph1_ir->dest->in_loop != 0)
+                set_var_liveout(ph1_ir->dest, loop_end_idx);
+            break;
+        case OP_write:
+            if (ph1_ir->src0->is_func == 0)
+                set_var_liveout(ph1_ir->src0, i);
+            set_var_liveout(ph1_ir->dest, i);
+            break;
+        case OP_indirect:
+            set_var_liveout(ph1_ir->src0, i);
+            break;
+        case OP_add:
+        case OP_sub:
+        case OP_mul:
+        case OP_div:
+        case OP_mod:
         case OP_eq:
         case OP_neq:
-        case OP_lt:
-        case OP_leq:
         case OP_gt:
+        case OP_lt:
         case OP_geq:
-            /* we want 1/nonzero if equ, 0 otherwise */
-            switch (op) {
-            case OP_eq:
-                emit(__beq(dest_reg, OP_reg, 12));
-                break;
-            case OP_neq:
-                emit(__bne(dest_reg, OP_reg, 12));
-                break;
-            case OP_lt:
-                emit(__blt(dest_reg, OP_reg, 12));
-                break;
-            case OP_geq:
-                emit(__bge(dest_reg, OP_reg, 12));
-                break;
-            case OP_gt:
-                emit(__blt(OP_reg, dest_reg, 12));
-                break;
-            case OP_leq:
-                emit(__bge(OP_reg, dest_reg, 12));
-                break;
-            default:
-                error("Unsupported conditional IR op");
-                break;
-            }
-            emit(__addi(dest_reg, __zero, 0));
-            emit(__jal(__zero, 8));
-            emit(__addi(dest_reg, __zero, 1));
-
-            if (dump_ir == 1) {
-                switch (op) {
-                case OP_eq:
-                    printf("    x%d == x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_neq:
-                    printf("    x%d != x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_lt:
-                    printf("    x%d < x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_geq:
-                    printf("    x%d >= x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_gt:
-                    printf("    x%d > x%d ?", dest_reg, OP_reg);
-                    break;
-                case OP_leq:
-                    printf("    x%d <= x%d ?", dest_reg, OP_reg);
-                    break;
-                default:
-                    break;
-                }
-            }
-            break;
-        case OP_log_and:
-            /* we assume both have to be 1, they can not be just nonzero */
-            emit(__and(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d &&= x%d", dest_reg, OP_reg);
-            break;
-        case OP_log_or:
-            emit(__or(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d ||= x%d", dest_reg, OP_reg);
-            break;
+        case OP_leq:
         case OP_bit_and:
-            emit(__and(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d &= x%d", dest_reg, OP_reg);
-            break;
         case OP_bit_or:
-            emit(__or(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d |= x%d", dest_reg, OP_reg);
-            break;
         case OP_bit_xor:
-            emit(__xor(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d ^= x%d", dest_reg, OP_reg);
+        case OP_log_and:
+        case OP_log_or:
+        case OP_rshift:
+        case OP_lshift:
+            set_var_liveout(ph1_ir->src0, i);
+            set_var_liveout(ph1_ir->src1, i);
+            if (loop_end_idx != 0) {
+                ph1_ir->src0->in_loop = 1;
+                ph1_ir->src1->in_loop = 1;
+            }
+            if (ph1_ir->dest->in_loop != 0)
+                set_var_liveout(ph1_ir->dest, loop_end_idx);
             break;
         case OP_bit_not:
-            emit(__xori(dest_reg, dest_reg, -1));
-            if (dump_ir == 1)
-                printf("    x%d ~= x%d", dest_reg, OP_reg);
-            break;
-        case OP_lshift:
-            emit(__sll(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d <<= x%d", dest_reg, OP_reg);
-            break;
-        case OP_rshift:
-            emit(__srl(dest_reg, dest_reg, OP_reg));
-            if (dump_ir == 1)
-                printf("    x%d >>= x%d", dest_reg, OP_reg);
-            break;
         case OP_log_not:
-            /* 1 if zero, 0 if nonzero */
-            /* only works for small range integers */
-            emit(__sltiu(dest_reg, dest_reg, 1));
-            if (dump_ir == 1)
-                printf("    !x%d", dest_reg);
-            break;
-        case OP_jz:
-        case OP_jnz: {
-            /* conditional jumps to IR-index */
-            int jump_instr_index = ii->int_param1;
-            ir_instr_t *jump_instr = &IR[jump_instr_index];
-            int jump_location = jump_instr->code_offset;
-            int ofs = jump_location - pc - 4;
-
-            if (ofs >= -4096 && ofs <= 4095) {
-                if (op == OP_jz) { /* near jump (branch) */
-                    emit(__nop());
-                    emit(__beq(dest_reg, __zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if false then goto %d", ii->int_param1);
-                } else if (op == OP_jnz) {
-                    emit(__nop());
-                    emit(__bne(dest_reg, __zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if true then goto %d", ii->int_param1);
-                }
-            } else { /* far jump */
-                if (op == OP_jz) {
-                    /* skip next instruction */
-                    emit(__bne(dest_reg, __zero, 8));
-                    emit(__jal(__zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if false then goto %d", ii->int_param1);
-                } else if (op == OP_jnz) {
-                    emit(__beq(dest_reg, __zero, 8));
-                    emit(__jal(__zero, ofs));
-                    if (dump_ir == 1)
-                        printf("    if true then goto %d", ii->int_param1);
-                }
-            }
-        } break;
-        case OP_block_start:
-            blk = &BLOCKS[ii->int_param1];
-            if (blk->next_local > 0) {
-                /* reserve stack space for locals */
-                emit(__addi(__sp, __sp, -blk->locals_size));
-                stack_size += blk->locals_size;
-            }
-            if (dump_ir == 1)
-                printf("    {");
-            _c_block_level++;
-            break;
-        case OP_block_end:
-            blk = &BLOCKS[ii->int_param1]; /* should not be necessarry */
-            if (blk->next_local > 0) {
-                /* remove stack space for locals */
-                emit(__addi(__sp, __sp, blk->locals_size));
-                stack_size -= blk->locals_size;
-            }
-            /* blk is current block */
-            blk = blk->parent;
-            if (dump_ir == 1)
-                printf("}");
-            _c_block_level--;
-            break;
-        case OP_func_extry: {
-            int pn, ps;
-            fn = find_func(ii->str_param1);
-            ps = fn->params_size;
-
-            /* add to symbol table */
-            elf_add_symbol(ii->str_param1, strlen(ii->str_param1),
-                           code_start + pc);
-
-            /* create stack space for params and parent frame */
-            emit(__addi(__sp, __sp, -16 - ps));
-            emit(__sw(__s0, __sp, 12 + ps));
-            emit(__sw(__ra, __sp, 8 + ps));
-            emit(__addi(__s0, __sp, ps));
-            stack_size = ps;
-
-            /* push parameters on stack */
-            for (pn = 0; pn < fn->num_params; pn++) {
-                emit(__sw(__a0 + pn, __s0, -fn->param_defs[pn].offset));
-            }
-            if (dump_ir == 1)
-                printf("%s:", ii->str_param1);
-        } break;
-        case OP_start:
-            emit(__lw(__a0, __sp, 0));   /* argc */
-            emit(__addi(__a1, __sp, 4)); /* argv */
-            if (dump_ir == 1)
-                printf("    start");
-            break;
-        case OP_syscall:
-            emit(__addi(__a7, __a0, 0));
-            emit(__addi(__a0, __a1, 0));
-            emit(__addi(__a1, __a2, 0));
-            emit(__addi(__a2, __a3, 0));
-            emit(__ecall());
-            if (dump_ir == 1)
-                printf("    syscall");
-            break;
-        case OP_exit:
-            emit(__add(__a0, __zero, OP_reg));
-            emit(__addi(__a7, __zero, 93));
-            emit(__ecall());
-            if (dump_ir == 1)
-                printf("    exit");
+        case OP_negate:
+            set_var_liveout(ph1_ir->src0, i);
+            if (loop_end_idx != 0)
+                ph1_ir->src0->in_loop = 1;
+            if (ph1_ir->dest->in_loop != 0)
+                set_var_liveout(ph1_ir->dest, loop_end_idx);
             break;
         default:
-            error("Unsupported IR op");
+            break;
         }
-        if (dump_ir == 1)
-            printf("\n");
+    }
+
+    /* initiate register file */
+    for (i = 0; i < REG_CNT; i++) {
+        REG[i].var = NULL;
+        REG[i].polluted = 0;
+    }
+
+    for (i = 0; i < global_ir_idx; i++) {
+        ph1_ir = &GLOBAL_IR[i];
+
+        if (ph1_ir->op == OP_allocat) {
+            func_t *t = &FUNCS[0];
+            ph1_ir->src0->offset = t->stack_size;
+            if (ph1_ir->src0->array_size == 0) {
+                if (ph1_ir->src0->is_ptr) {
+                    t->stack_size += 4;
+                } else if (strcmp(ph1_ir->src0->type_name, "int") &&
+                           strcmp(ph1_ir->src0->type_name, "char")) {
+                    type_t *type = find_type(ph1_ir->src0->type_name);
+                    t->stack_size += type->size;
+                } else
+                    t->stack_size += 4;
+            } else {
+                int sz = t->stack_size;
+                t->stack_size += PTR_SIZE;
+
+                reg_idx = get_dest_reg(t, ph1_ir->src0, i, -1, -1, 0);
+
+                ph2_ir = add_ph2_ir(OP_global_addr_of);
+                ph2_ir->src0 = t->stack_size;
+                ph2_ir->dest = reg_idx;
+
+                if (ph1_ir->src0->is_ptr)
+                    t->stack_size += PTR_SIZE * ph1_ir->src0->array_size;
+                else {
+                    type_t *type = find_type(ph1_ir->src0->type_name);
+                    t->stack_size += type->size * ph1_ir->src0->array_size;
+                }
+
+                ph2_ir = add_ph2_ir(OP_global_store);
+                ph2_ir->src0 = reg_idx;
+                ph2_ir->src1 = sz;
+            }
+        } else if (ph1_ir->op == OP_load_constant) {
+            func_t *fn = &FUNCS[0];
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, -1, -1, 0);
+            ph2_ir = add_ph2_ir(OP_load_constant);
+            ph2_ir->src0 = ph1_ir->dest->init_val;
+            ph2_ir->dest = reg_idx;
+        } else if (ph1_ir->op == OP_assign) {
+            func_t *fn = &FUNCS[0];
+            int ofs;
+
+            reg_idx_src0 = get_src_reg(fn, ph1_ir->src0, -1);
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, reg_idx_src0, -1, 0);
+            ph2_ir = add_ph2_ir(OP_assign);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->dest = reg_idx;
+
+            ph2_ir = add_ph2_ir(OP_global_store);
+            ofs = ph1_ir->dest->offset;
+            ph2_ir->src0 = reg_idx;
+            ph2_ir->src1 = ofs;
+        } else
+            error("Unsupported global operation");
+    }
+
+    /* jump to entry point after global statements */
+    ph2_ir = add_ph2_ir(OP_jump);
+    strcpy(ph2_ir->func_name, "main");
+
+    for (i = 0; i < ph1_ir_idx; i++) {
+        ph1_ir = &PH1_IR[i];
+        expire_regs(i);
+
+        if (i > 0 &&
+            (PH1_IR[i - 1].op == OP_call || PH1_IR[i - 1].op == OP_indirect))
+            for (j = 0; j < REG_CNT; j++)
+                REG[j].var = NULL;
+
+        switch (ph1_ir->op) {
+        case OP_block_end:
+            if (PH1_IR[i - 1].op != OP_return)
+                spill_used_regs(fn, -1, 1);
+            ph2_ir = add_ph2_ir(OP_block_end);
+            break;
+        case OP_define:
+            fn = find_func(ph1_ir->func_name);
+            ph2_ir = add_ph2_ir(OP_define);
+            strcpy(ph2_ir->func_name, ph1_ir->func_name);
+
+            /* set arguments availiable, more than 8 will cause error */
+            for (j = 0; j < fn->num_params; j++) {
+                REG[j].var = &fn->param_defs[j];
+                REG[j].polluted = 1;
+            }
+            for (; j < REG_CNT; j++) {
+                REG[j].var = NULL;
+                REG[j].polluted = 0;
+            }
+
+            spill_used_regs(fn, -1, 0);
+
+            break;
+        case OP_allocat: {
+            func_t *t;
+
+            if (ph1_ir->src0->is_global == 1)
+                t = &FUNCS[0];
+            else
+                t = fn;
+
+            ph1_ir->src0->offset = t->stack_size;
+            if (ph1_ir->src0->array_size == 0) {
+                if (ph1_ir->src0->is_ptr) {
+                    t->stack_size += 4;
+                } else if (strcmp(ph1_ir->src0->type_name, "int") &&
+                           strcmp(ph1_ir->src0->type_name, "char")) {
+                    type_t *type = find_type(ph1_ir->src0->type_name);
+                    t->stack_size += type->size;
+                } else
+                    t->stack_size += 4;
+            } else {
+                int sz = t->stack_size;
+                t->stack_size += PTR_SIZE;
+
+                reg_idx = get_dest_reg(t, ph1_ir->src0, i, -1, -1, 0);
+
+                if (ph1_ir->src0->is_global == 1)
+                    ph2_ir = add_ph2_ir(OP_global_addr_of);
+                else
+                    ph2_ir = add_ph2_ir(OP_address_of);
+                ph2_ir->src0 = t->stack_size;
+                ph2_ir->dest = reg_idx;
+
+                if (ph1_ir->src0->is_ptr)
+                    t->stack_size += PTR_SIZE * ph1_ir->src0->array_size;
+                else {
+                    type_t *type = find_type(ph1_ir->src0->type_name);
+                    t->stack_size += type->size * ph1_ir->src0->array_size;
+                }
+                if (ph1_ir->src0->is_global == 1)
+                    ph2_ir = add_ph2_ir(OP_global_store);
+                else
+                    ph2_ir = add_ph2_ir(OP_store);
+                ph2_ir->src0 = reg_idx;
+                ph2_ir->src1 = sz;
+            }
+        } break;
+        case OP_load_constant:
+        case OP_load_data_address:
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, -1, -1, 0);
+            ph2_ir = add_ph2_ir(ph1_ir->op);
+            ph2_ir->src0 = ph1_ir->dest->init_val;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_label:
+            if (PH1_IR[i - 1].op == OP_branch)
+                if (strcmp(PH1_IR[i - 1].src0->var_name,
+                           ph1_ir->src0->var_name))
+                    for (j = 0; j < REG_CNT; j++)
+                        REG->var = NULL;
+
+            /* spill at the beginning of the while statement */
+            if (PH1_IR[i - 1].op != OP_branch && PH1_IR[i - 1].op != OP_jump)
+                spill_used_regs(fn, -1, 0);
+
+            ph2_ir = add_ph2_ir(OP_label);
+            strcpy(ph2_ir->func_name, ph1_ir->src0->var_name);
+            break;
+        case OP_jump:
+            spill_used_regs(fn, -1, 0);
+            ph2_ir = add_ph2_ir(OP_jump);
+            strcpy(ph2_ir->func_name, ph1_ir->dest->var_name);
+            break;
+        case OP_branch:
+            spill_used_regs(fn, i, 0);
+            reg_idx_src0 = get_src_reg(fn, ph1_ir->dest, -1);
+            ph2_ir = add_ph2_ir(OP_branch);
+            ph2_ir->src0 = reg_idx_src0;
+            strcpy(ph2_ir->true_label, ph1_ir->src0->var_name);
+            strcpy(ph2_ir->false_label, ph1_ir->src1->var_name);
+            break;
+        case OP_push:
+            if (argument_idx == 0)
+                spill_used_regs(fn, -1, 0);
+
+            ofs = ph1_ir->src0->offset;
+            if (ph1_ir->src0->is_global)
+                ph2_ir = add_ph2_ir(OP_global_load);
+            else
+                ph2_ir = add_ph2_ir(OP_load);
+            ph2_ir->src0 = ofs;
+            ph2_ir->dest = argument_idx;
+            argument_idx++;
+            break;
+        case OP_call:
+            if (PH1_IR[i - 1].op != OP_push)
+                spill_used_regs(fn, -1, 0);
+            ph2_ir = add_ph2_ir(OP_call);
+            strcpy(ph2_ir->func_name, ph1_ir->func_name);
+            argument_idx = 0;
+            break;
+        case OP_func_ret:
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, 0, -1, 0);
+            ph2_ir = add_ph2_ir(OP_assign);
+            ph2_ir->src0 = 0;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_return:
+            spill_used_regs(fn, -1, 1);
+
+            if (ph1_ir->src0)
+                reg_idx_src0 = get_src_reg(fn, ph1_ir->src0, -1);
+            else
+                reg_idx_src0 = -1;
+
+            ph2_ir = add_ph2_ir(OP_return);
+            ph2_ir->src0 = reg_idx_src0;
+            break;
+        case OP_address_of:
+            ofs = ph1_ir->src0->offset;
+            if (ofs == 0) {
+                for (j = 0; j < REG_CNT; j++)
+                    if (REG[j].var == ph1_ir->src0)
+                        break;
+                ph2_ir = add_ph2_ir(OP_store);
+                if (ph1_ir->src0->is_global) {
+                    ofs = FUNCS[0].stack_size;
+                    FUNCS[0].stack_size += 4;
+                } else {
+                    ofs = fn->stack_size;
+                    fn->stack_size += 4;
+                }
+                ph1_ir->src0->offset = ofs;
+                ph2_ir->src0 = j;
+                ph2_ir->src1 = ofs;
+            }
+
+            /* write the content back into stack, prevent to get the obsolete
+             * content when dereferencing */
+            for (j = 0; j < REG_CNT; j++)
+                if (REG[j].var == ph1_ir->src0)
+                    if (REG[j].polluted) {
+                        if (REG[j].var->is_global)
+                            ph2_ir = add_ph2_ir(OP_global_store);
+                        else
+                            ph2_ir = add_ph2_ir(OP_store);
+                        ph2_ir->src0 = j;
+                        ph2_ir->src1 = ofs;
+                    }
+
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, -1, -1, 0);
+
+            if (ph1_ir->src0->is_global)
+                ph2_ir = add_ph2_ir(OP_global_addr_of);
+            else
+                ph2_ir = add_ph2_ir(OP_address_of);
+            ph2_ir->src0 = ofs;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_read:
+            reg_idx_src0 = get_src_reg(fn, ph1_ir->src0, -1);
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, reg_idx_src0, -1, 0);
+            ph2_ir = add_ph2_ir(OP_read);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->src1 = ph1_ir->size;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_write:
+            if (ph1_ir->src0->is_func == 0) {
+                /* without this, the content stored in register which represent
+                 * to a var won't be updated after writing into its reference */
+                spill_used_regs(fn, -1, 0);
+
+                reg_idx_src0 = get_src_reg(fn, ph1_ir->src0, -1);
+                reg_idx_src1 = get_src_reg(fn, ph1_ir->dest, reg_idx_src0);
+                ph2_ir = add_ph2_ir(OP_write);
+                ph2_ir->src0 = reg_idx_src0;
+                ph2_ir->src1 = reg_idx_src1;
+                ph2_ir->dest = ph1_ir->size;
+            } else {
+                reg_idx_src0 = get_src_reg(fn, ph1_ir->dest, -1);
+                ph2_ir = add_ph2_ir(OP_func_addr);
+                ph2_ir->src0 = reg_idx_src0;
+                strcpy(ph2_ir->func_name, ph1_ir->src0->var_name);
+            }
+            break;
+        case OP_indirect:
+            if (PH1_IR[i - 1].op != OP_push)
+                spill_used_regs(fn, -1, 0);
+
+            ofs = ph1_ir->src0->offset;
+
+            /* workaround: load into register t6 */
+            ph2_ir = add_ph2_ir(OP_load);
+            ph2_ir->src0 = ofs;
+            ph2_ir->dest = 21;
+            ph2_ir = add_ph2_ir(OP_indirect);
+            argument_idx = 0;
+            break;
+        case OP_assign:
+        case OP_negate:
+        case OP_bit_not:
+        case OP_log_not:
+            reg_idx_src0 = get_src_reg(fn, ph1_ir->src0, -1);
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, reg_idx_src0, -1, 0);
+            ph2_ir = add_ph2_ir(ph1_ir->op);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_add:
+        case OP_sub:
+        case OP_mul:
+        case OP_div:
+        case OP_mod:
+        case OP_eq:
+        case OP_neq:
+        case OP_gt:
+        case OP_lt:
+        case OP_geq:
+        case OP_leq:
+        case OP_bit_and:
+        case OP_bit_or:
+        case OP_bit_xor:
+        case OP_log_or:
+        case OP_rshift:
+        case OP_lshift:
+            reg_idx_src0 = get_src_reg(fn, ph1_ir->src0, -1);
+            reg_idx_src1 = get_src_reg(fn, ph1_ir->src1, reg_idx_src0);
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, reg_idx_src0,
+                                   reg_idx_src1, 0);
+            ph2_ir = add_ph2_ir(ph1_ir->op);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->src1 = reg_idx_src1;
+            ph2_ir->dest = reg_idx;
+            break;
+        case OP_log_and:
+            /* workaround: see details at the codegen of OP_log_and */
+            reg_idx_src0 = get_src_reg(fn, ph1_ir->src0, -1);
+            reg_idx_src1 = get_src_reg(fn, ph1_ir->src1, reg_idx_src0);
+            reg_idx = get_dest_reg(fn, ph1_ir->dest, i, reg_idx_src0,
+                                   reg_idx_src1, 1);
+            ph2_ir = add_ph2_ir(ph1_ir->op);
+            ph2_ir->src0 = reg_idx_src0;
+            ph2_ir->src1 = reg_idx_src1;
+            ph2_ir->dest = reg_idx;
+            break;
+        default:
+            add_ph2_ir(ph1_ir->op);
+            break;
+        }
+    }
+
+    dump_ph2_ir();
+
+    add_label("__syscall", 24 + 20 + 16);
+
+    /* calculate the offset of labels */
+    elf_code_idx = 92 + 16; /* 72 + 20 */
+    for (i = 0; i < ph2_ir_idx; i++) {
+        ph2_ir = &PH2_IR[i];
+
+        switch (ph2_ir->op) {
+        case OP_define:
+            fn = find_func(ph2_ir->func_name);
+            add_label(ph2_ir->func_name, elf_code_idx);
+            elf_code_idx += 12 + 8;
+            break;
+        case OP_block_start:
+            block_lv++;
+            break;
+        case OP_block_end:
+            /* handle the function with the implicit return */
+            --block_lv;
+            if (block_lv != 0)
+                break;
+            if (!strcmp(fn->return_def.type_name, "void"))
+                elf_code_idx += 16 + 8;
+            break;
+        case OP_label:
+            add_label(ph2_ir->func_name, elf_code_idx);
+            break;
+        case OP_assign:
+            if (ph2_ir->dest != ph2_ir->src0)
+                elf_code_idx += 4;
+            break;
+        case OP_store:
+            if (ph2_ir->src1 < -2048 || ph2_ir->src1 > 2047)
+                elf_code_idx += 16;
+            else
+                elf_code_idx += 4;
+            break;
+        case OP_load:
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047)
+                elf_code_idx += 16;
+            else
+                elf_code_idx += 4;
+            break;
+        case OP_global_load:
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047)
+                elf_code_idx += 16;
+            else
+                elf_code_idx += 4;
+            break;
+        case OP_global_store:
+            if (ph2_ir->src1 < -2048 || ph2_ir->src1 > 2047)
+                elf_code_idx += 16;
+            else
+                elf_code_idx += 4;
+            break;
+        case OP_global_addr_of:
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047)
+                elf_code_idx += 12;
+            else
+                elf_code_idx += 4;
+            break;
+        case OP_address_of:
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047)
+                elf_code_idx += 12;
+            else
+                elf_code_idx += 4;
+            break;
+        case OP_jump:
+            if (!strcmp(ph2_ir->func_name, "main"))
+                elf_code_idx += 20;
+            elf_code_idx += 4;
+            break;
+        case OP_call:
+        case OP_read:
+        case OP_write:
+        case OP_negate:
+        case OP_add:
+        case OP_sub:
+        case OP_mul:
+        case OP_div:
+        case OP_mod:
+        case OP_gt:
+        case OP_lt:
+        case OP_bit_and:
+        case OP_bit_or:
+        case OP_bit_xor:
+        case OP_bit_not:
+        case OP_rshift:
+        case OP_lshift:
+        case OP_indirect:
+            elf_code_idx += 4;
+            break;
+        case OP_load_constant:
+            if (ph2_ir->src0 > -2048 && ph2_ir->src0 < 2047)
+                elf_code_idx += 4;
+            else
+                elf_code_idx += 8;
+            break;
+        case OP_load_data_address:
+        case OP_neq:
+        case OP_geq:
+        case OP_leq:
+        case OP_log_or:
+        case OP_log_not:
+            elf_code_idx += 8;
+            break;
+        case OP_eq:
+        case OP_func_addr:
+            elf_code_idx += 12;
+            break;
+        case OP_log_and:
+            elf_code_idx += 16;
+            break;
+        case OP_branch:
+            elf_code_idx += 20;
+            break;
+        case OP_return:
+            elf_code_idx += 20 + 8;
+            break;
+        default:
+            break;
+        }
+    }
+
+    elf_data_start = elf_code_start + elf_code_idx;
+    block_lv = 0;
+    elf_code_idx = 0;
+
+    /* manually insert the entry, exit and syscall */
+    elf_add_symbol("__start", strlen("__start"), 0);
+    emit(__sw(__gp, __sp, -4));
+    emit(__lw(__a0, __sp, 0));   /* argc */
+    emit(__addi(__a1, __sp, 4)); /* argv */
+    emit(__lui(__a7, rv_hi(FUNCS[0].stack_size + 4)));
+    emit(__addi(__a7, __a7, rv_lo(FUNCS[0].stack_size + 4)));
+    emit(__sub(__sp, __sp, __a7));
+    emit(__addi(__gp, __sp, 0));
+    emit(__jal(__ra, 108 - elf_code_idx));
+
+    elf_add_symbol("__exit", strlen("__exit"), elf_code_idx);
+    emit(__lui(__a7, rv_hi(FUNCS[0].stack_size + 4)));
+    emit(__addi(__a7, __a7, rv_lo(FUNCS[0].stack_size + 4)));
+    emit(__add(__sp, __sp, __a7));
+    emit(__lw(__gp, __sp, -4));
+    emit(__addi(__a0, __a0, 0));
+    emit(__addi(__a7, __zero, 93));
+    emit(__ecall());
+
+    elf_add_symbol("__syscall", strlen("__syscall"), elf_code_idx);
+    emit(__addi(__sp, __sp, -8));
+    emit(__sw(__ra, __sp, 0));
+    emit(__sw(__s0, __sp, 4));
+    emit(__addi(__a7, __a0, 0));
+    emit(__addi(__a0, __a1, 0));
+    emit(__addi(__a1, __a2, 0));
+    emit(__addi(__a2, __a3, 0));
+    emit(__ecall());
+    emit(__lw(__s0, __sp, 4));
+    emit(__lw(__ra, __sp, 0));
+    emit(__addi(__sp, __sp, 8));
+    emit(__jalr(__zero, __ra, 0));
+
+    /* use brace in switch statement to lower the MAX_LOCALS when
+     * self-hosting */
+    for (i = 0; i < ph2_ir_idx; i++) {
+        ph2_ir = &PH2_IR[i];
+
+        switch (ph2_ir->op) {
+        case OP_define: {
+            fn = find_func(ph2_ir->func_name);
+            emit(__sw(__ra, __sp, -8));
+            emit(__sw(__s0, __sp, -4));
+            emit(__lui(__s0, rv_hi(fn->stack_size + 8)));
+            emit(__addi(__s0, __s0, rv_lo(fn->stack_size + 8)));
+            emit(__sub(__sp, __sp, __s0));
+        } break;
+        case OP_block_start:
+            block_lv++;
+            break;
+        case OP_block_end: {
+            --block_lv;
+            if (block_lv != 0)
+                break;
+            if (!strcmp(fn->return_def.type_name, "void")) {
+                emit(__lui(__s0, rv_hi(fn->stack_size + 8)));
+                emit(__addi(__s0, __s0, rv_lo(fn->stack_size + 8)));
+                emit(__add(__sp, __sp, __s0));
+                emit(__lw(__s0, __sp, -4));
+                emit(__lw(__ra, __sp, -8));
+                emit(__jalr(__zero, __ra, 0));
+            }
+        } break;
+        case OP_load_constant: {
+            if (ph2_ir->src0 > -2048 && ph2_ir->src0 < 2047)
+                emit(__addi(ph2_ir->dest + 10, __zero, ph2_ir->src0));
+            else {
+                emit(__lui(ph2_ir->dest + 10, rv_hi(ph2_ir->src0)));
+                emit(__addi(ph2_ir->dest + 10, ph2_ir->dest + 10,
+                            rv_lo(ph2_ir->src0)));
+            }
+        } break;
+        case OP_load_data_address: {
+            emit(
+                __lui(ph2_ir->dest + 10, rv_hi(ph2_ir->src0 + elf_data_start)));
+            emit(__addi(ph2_ir->dest + 10, ph2_ir->dest + 10,
+                        rv_lo(ph2_ir->src0 + elf_data_start)));
+        } break;
+        case OP_address_of: {
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047) {
+                emit(__lui(__t6, rv_hi(ph2_ir->src0)));
+                emit(__addi(__t6, __t6, rv_lo(ph2_ir->src0)));
+                emit(__add(ph2_ir->dest + 10, __t6, __sp));
+            } else
+                emit(__addi(ph2_ir->dest + 10, __sp, ph2_ir->src0));
+        } break;
+        case OP_assign: {
+            if (ph2_ir->dest != ph2_ir->src0)
+                emit(__addi(ph2_ir->dest + 10, ph2_ir->src0 + 10, 0));
+        } break;
+        case OP_branch: {
+            /* the absolute address is the offset + the beginning of the
+             * instrution (0x10054)*/
+            ofs = find_label_offset(ph2_ir->false_label);
+            emit(__lui(__t6, rv_hi(ofs + 65620)));
+            emit(__addi(__t6, __t6, rv_lo(ofs + 65620)));
+            emit(__bne(ph2_ir->src0 + 10, __zero, 8));
+            emit(__jalr(__zero, __t6, 0));
+
+            ofs = find_label_offset(ph2_ir->true_label);
+            emit(__jal(__zero, ofs - elf_code_idx));
+        } break;
+        case OP_jump: {
+            if (!strcmp(ph2_ir->func_name, "main")) {
+                emit(__lui(__t6, rv_hi(FUNCS[0].stack_size + 4)));
+                emit(__addi(__t6, __t6, rv_lo(FUNCS[0].stack_size + 4)));
+                emit(__add(__t6, __sp, __t6));
+                emit(__lw(__a0, __t6, 0));
+                emit(__addi(__a1, __t6, 4));
+            }
+
+            ofs = find_label_offset(ph2_ir->func_name);
+            emit(__jal(__zero, ofs - elf_code_idx));
+        } break;
+        case OP_load: {
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047) {
+                emit(__lui(__t6, rv_hi(ph2_ir->src0)));
+                emit(__addi(__t6, __t6, rv_lo(ph2_ir->src0)));
+                emit(__add(__t6, __t6, __sp));
+                emit(__lw(ph2_ir->dest + 10, __t6, 0));
+            } else
+                emit(__lw(ph2_ir->dest + 10, __sp, ph2_ir->src0));
+        } break;
+        case OP_store: {
+            if (ph2_ir->src1 < -2048 || ph2_ir->src1 > 2047) {
+                emit(__lui(__t6, rv_hi(ph2_ir->src1)));
+                emit(__addi(__t6, __t6, rv_lo(ph2_ir->src1)));
+                emit(__add(__t6, __t6, __sp));
+                emit(__sw(ph2_ir->src0 + 10, __t6, 0));
+            } else
+                emit(__sw(ph2_ir->src0 + 10, __sp, ph2_ir->src1));
+        } break;
+        case OP_global_load: {
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047) {
+                emit(__lui(__t6, rv_hi(ph2_ir->src0)));
+                emit(__addi(__t6, __t6, rv_lo(ph2_ir->src0)));
+                emit(__add(__t6, __t6, __gp));
+                emit(__lw(ph2_ir->dest + 10, __t6, 0));
+            } else
+                emit(__lw(ph2_ir->dest + 10, __gp, ph2_ir->src0));
+        } break;
+        case OP_global_store: {
+            if (ph2_ir->src1 < -2048 || ph2_ir->src1 > 2047) {
+                emit(__lui(__t6, rv_hi(ph2_ir->src1)));
+                emit(__addi(__t6, __t6, rv_lo(ph2_ir->src1)));
+                emit(__add(__t6, __t6, __gp));
+                emit(__sw(ph2_ir->src0 + 10, __t6, 0));
+            } else
+                emit(__sw(ph2_ir->src0 + 10, __gp, ph2_ir->src1));
+        } break;
+        case OP_global_addr_of: {
+            if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047) {
+                emit(__lui(__t6, rv_hi(ph2_ir->src0)));
+                emit(__addi(__t6, __t6, rv_lo(ph2_ir->src0)));
+                emit(__add(ph2_ir->dest + 10, __t6, __gp));
+            } else
+                emit(__addi(ph2_ir->dest + 10, __gp, ph2_ir->src0));
+        } break;
+        case OP_read: {
+            if (ph2_ir->src1 == 1)
+                emit(__lb(ph2_ir->dest + 10, ph2_ir->src0 + 10, 0));
+            else if (ph2_ir->src1 == 4)
+                emit(__lw(ph2_ir->dest + 10, ph2_ir->src0 + 10, 0));
+            else
+                abort();
+        } break;
+        case OP_write:
+            if (ph2_ir->dest == 1)
+                emit(__sb(ph2_ir->src0 + 10, ph2_ir->src1 + 10, 0));
+            else if (ph2_ir->dest == 4)
+                emit(__sw(ph2_ir->src0 + 10, ph2_ir->src1 + 10, 0));
+            else
+                abort();
+            break;
+        case OP_func_addr:
+            /* the absolute address is the offset + the beginning of the
+             * instrution (0x10054)*/
+            ofs = find_label_offset(ph2_ir->func_name);
+            emit(__lui(__t6, rv_hi(ofs + 65620)));
+            emit(__addi(__t6, __t6, rv_lo(ofs + 65620)));
+            emit(__sw(__t6, ph2_ir->src0 + 10, 0));
+            break;
+        case OP_indirect:
+            emit(__jalr(__ra, __t6, 0));
+            break;
+        case OP_call:
+            ofs = find_label_offset(ph2_ir->func_name);
+            emit(__jal(__ra, ofs - elf_code_idx));
+            break;
+        case OP_return: {
+            if (ph2_ir->src0 == -1)
+                emit(__addi(__zero, __zero, 0));
+            else
+                emit(__addi(__a0, ph2_ir->src0 + 10, 0));
+            emit(__lui(__s0, rv_hi(fn->stack_size + 8)));
+            emit(__addi(__s0, __s0, rv_lo(fn->stack_size + 8)));
+            emit(__add(__sp, __sp, __s0));
+            emit(__lw(__s0, __sp, -4));
+            emit(__lw(__ra, __sp, -8));
+            emit(__jalr(__zero, __ra, 0));
+        } break;
+        case OP_negate:
+            emit(__sub(ph2_ir->dest + 10, __zero, ph2_ir->src0 + 10));
+            break;
+        case OP_add: {
+            emit(
+                __add(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_sub: {
+            emit(
+                __sub(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_mul: {
+            emit(
+                __mul(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_div: {
+            emit(
+                __div(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_mod: {
+            emit(
+                __mod(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_eq: {
+            emit(
+                __sub(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+        } break;
+        case OP_neq: {
+            emit(
+                __sub(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+        } break;
+        case OP_gt: {
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src1 + 10, ph2_ir->src0 + 10));
+        } break;
+        case OP_lt: {
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_geq: {
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+        } break;
+        case OP_leq: {
+            emit(
+                __slt(ph2_ir->dest + 10, ph2_ir->src1 + 10, ph2_ir->src0 + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+        } break;
+        case OP_bit_and: {
+            emit(
+                __and(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_bit_or: {
+            emit(__or(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_bit_xor: {
+            emit(
+                __xor(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_bit_not:
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->src0 + 10, -1));
+            break;
+        /* workaround for the logical-and (&&) operation */
+        case OP_log_and:
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->src0 + 10));
+            emit(__sub(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            emit(
+                __and(ph2_ir->dest + 10, ph2_ir->dest + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+            break;
+        case OP_log_or: {
+            emit(__or(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->dest + 10));
+        } break;
+        case OP_log_not: {
+            emit(__sltu(ph2_ir->dest + 10, __zero, ph2_ir->src0 + 10));
+            emit(__xori(ph2_ir->dest + 10, ph2_ir->dest + 10, 1));
+        } break;
+        case OP_rshift: {
+            emit(
+                __sra(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_lshift: {
+            emit(
+                __sll(ph2_ir->dest + 10, ph2_ir->src0 + 10, ph2_ir->src1 + 10));
+        } break;
+        case OP_label:
+            break;
+        default:
+            abort();
+            break;
+        }
+    }
+}
+
+/* Not support "%c" in printf() yet */
+void dump_ph2_ir()
+{
+    ph2_ir_t *ph2_ir;
+    int i;
+
+    if (dump_ir == 0)
+        return;
+
+    for (i = 0; i < ph2_ir_idx; i++) {
+        ph2_ir = &PH2_IR[i];
+
+        switch (ph2_ir->op) {
+        case OP_define:
+            printf("%s:", ph2_ir->func_name);
+            break;
+        case OP_block_start:
+        case OP_block_end:
+        case OP_allocat:
+            continue;
+        case OP_load_constant:
+            printf("\tli %%a%c, $%d", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_address_of:
+            printf("\t%%a%c = %%sp + %d", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_global_addr_of:
+            printf("\t%%a%c = %%gp + %d", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_load_data_address:
+            printf("\t%%a%c = .data(%d)", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_assign:
+            printf("\t%%a%c = %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_branch:
+            printf("\tbr %%a%c, %s, %s", ph2_ir->src0 + 48, ph2_ir->true_label,
+                   ph2_ir->false_label);
+            break;
+        case OP_label:
+            printf("%s:", ph2_ir->func_name);
+            break;
+        case OP_jump:
+            printf("\tj %s", ph2_ir->func_name);
+            break;
+        case OP_load:
+            printf("\tload %%a%c, %d(sp)", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_store:
+            printf("\tstore %%a%c, %d(sp)", ph2_ir->src0 + 48, ph2_ir->src1);
+            break;
+        case OP_global_load:
+            printf("\tload %%a%c, %d(gp)", ph2_ir->dest + 48, ph2_ir->src0);
+            break;
+        case OP_global_store:
+            printf("\tstore %%a%c, %d(gp)", ph2_ir->src0 + 48, ph2_ir->src1);
+            break;
+        case OP_read:
+            printf("\t%%a%c = (%%a%c)", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_write:
+            printf("\t(%%a%c) = %%a%c", ph2_ir->src1 + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_func_addr:
+            printf("\t(%%a%c) = @%s", ph2_ir->src0 + 48, ph2_ir->func_name);
+            break;
+        case OP_indirect:
+            printf("\tindirect call @(%%t6)");
+            break;
+        case OP_call:
+            printf("\tcall @%s", ph2_ir->func_name);
+            break;
+        case OP_return:
+            if (ph2_ir->src0 == -1)
+                printf("\tret");
+            else
+                printf("\tret %%a%c", ph2_ir->src0 + 48);
+            break;
+        case OP_negate:
+            printf("\tneg %%a%c, %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_add:
+            printf("\t%%a%c = add %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_sub:
+            printf("\t%%a%c = sub %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_mul:
+            printf("\t%%a%c = mul %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_div:
+            printf("\t%%a%c = div %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_mod:
+            printf("\t%%a%c = mod %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_eq:
+            printf("\t%%a%c = eq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_neq:
+            printf("\t%%a%c = neq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_gt:
+            printf("\t%%a%c = gt %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_lt:
+            printf("\t%%a%c = lt %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_geq:
+            printf("\t%%a%c = geq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_leq:
+            printf("\t%%a%c = leq %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_bit_and:
+            printf("\t%%a%c = and %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_bit_or:
+            printf("\t%%a%c = or %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_bit_not:
+            printf("\t%%a%c = not %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_bit_xor:
+            printf("\t%%a%c = xor %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_log_and:
+            printf("\t%%a%c = and %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_log_or:
+            printf("\t%%a%c = or %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_log_not:
+            printf("\t%%a%c = not %%a%c", ph2_ir->dest + 48, ph2_ir->src0 + 48);
+            break;
+        case OP_rshift:
+            printf("\t%%a%c = rshift %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        case OP_lshift:
+            printf("\t%%a%c = lshift %%a%c, %%a%c", ph2_ir->dest + 48,
+                   ph2_ir->src0 + 48, ph2_ir->src1 + 48);
+            break;
+        default:
+            break;
+        }
+        printf("\n");
     }
 }

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -207,7 +207,7 @@ items 5 "int b; int *a; b = 10; a = &b; a[0] = 5; return b;"
 items 2 "int x[2]; int y; x[1] = 2; y = *(x + 1); return y;"
 items 2 "int x; int *y; int z; z = 2; y = &z; x = *y; return x;"
 try_ 10 << EOF
-int change_it(int *p) {
+void change_it(int *p) {
     if (p[0] == 0) {
         p[0] = 10;
     } else {


### PR DESCRIPTION
The newly two-phase IR replaces the origin one which was coupled with the the register allocation and made the optimization harder. In addition, the stack-based virtual machine uses the available registers inefficiently in RISC-like architecture.

The first-phase IR uses the three-address code (3AC) to simplify the complex expression. The register allocator could use these information to generate the more efficient instructions, using the algorithm that supports the register-base virtual machine. We use the linear-scan algorithm in this implementation.

The second-phase IR locates the symbol which is used in branch/jump instruction. Once the amount of the other instructions is confirmed, the offset/address could be correct.